### PR TITLE
Add support for grouping

### DIFF
--- a/js/dx.aspnet.data.js
+++ b/js/dx.aspnet.data.js
@@ -44,10 +44,10 @@
 
             var normalizeSorting = DX.data.utils.normalizeSortingInfo;
 
-            if("sort" in options)
+            if(options.sort)
                 result.sort = JSON.stringify(normalizeSorting(options.sort));
 
-            if("group" in options)
+            if(options.group)
                 result.group = JSON.stringify(normalizeSorting(options.group));
 
             if($.isArray(options.filter))

--- a/js/dx.aspnet.data.js
+++ b/js/dx.aspnet.data.js
@@ -42,8 +42,13 @@
                 take: options.take,
             };
 
-            if($.isArray(options.sort))
-                result.sort = JSON.stringify(options.sort);
+            var normalizeSorting = DX.data.utils.normalizeSortingInfo;
+
+            if("sort" in options)
+                result.sort = JSON.stringify(normalizeSorting(options.sort));
+
+            if("group" in options)
+                result.group = JSON.stringify(normalizeSorting(options.group));
 
             if($.isArray(options.filter))
                 result.filter = JSON.stringify(options.filter);

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -67,6 +67,25 @@ namespace DevExtreme.AspNet.Data.Tests {
             var expr = builder.Build(false);
             Assert.Equal("data.OrderBy(obj => obj.Item1).ThenByDescending(obj => obj.Item2)", expr.Body.ToString());
         }
+
+        [Fact]
+        public void GroupingAddedToSorting() {
+            var builder = new DataSourceExpressionBuilder<Tuple<int, int, int>> {
+                Sort = new[] {
+                    new SortingInfo { Selector = "Item2" },
+                    new SortingInfo { Selector = "Item3" }
+                },
+                Group = new[] {
+                    new GroupingInfo { Selector = "Item1" },
+                    new GroupingInfo { Selector = "Item2", Desc = true  } // this must win
+                }
+            };
+
+            Assert.Equal(
+                "data.OrderBy(obj => obj.Item1).ThenByDescending(obj => obj.Item2).ThenBy(obj => obj.Item3)",
+                builder.Build(false).Body.ToString()
+            );
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -13,7 +13,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 Take = 222
             };
 
-            var expr = builder.Build(false);
+            var expr = builder.BuildLoadExpr();
 
             Assert.Equal("data.Skip(111).Take(222)", expr.Body.ToString());
         }
@@ -24,7 +24,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 Filter = new object[] { "this", ">", 123 }
             };
 
-            var expr = builder.Build(false);
+            var expr = builder.BuildLoadExpr();
 
             Assert.Equal("data.Where(obj => (obj > 123))", expr.Body.ToString());
         }
@@ -40,7 +40,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 },
             };
 
-            var expr = builder.Build(true);
+            var expr = builder.BuildCountExpr();
             var text = expr.ToString();
 
             Assert.Contains("Where", text);
@@ -64,7 +64,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 }
             };
 
-            var expr = builder.Build(false);
+            var expr = builder.BuildLoadExpr();
             Assert.Equal("data.OrderBy(obj => obj.Item1).ThenByDescending(obj => obj.Item2)", expr.Body.ToString());
         }
 
@@ -83,7 +83,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             Assert.Equal(
                 "data.OrderBy(obj => obj.Item1).ThenByDescending(obj => obj.Item2).ThenBy(obj => obj.Item3)",
-                builder.Build(false).Body.ToString()
+                builder.BuildLoadExpr().Body.ToString()
             );
         }
     }

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoadOptionsParserTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoadOptionsParserTests.cs
@@ -18,6 +18,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 { DataSourceLoadOptionsParser.KEY_SKIP, "42" },
                 { DataSourceLoadOptionsParser.KEY_TAKE, "43" },
                 { DataSourceLoadOptionsParser.KEY_SORT, @"[ { ""selector"": ""foo"", ""desc"": true } ]" },
+                { DataSourceLoadOptionsParser.KEY_GROUP, @"[ { ""selector"": ""g"" } ]" },
                 { DataSourceLoadOptionsParser.KEY_FILTER, @" [ ""foo"", ""bar"" ] " },
             };
 
@@ -29,6 +30,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(43, opts.Take);
             Assert.Equal("foo", opts.Sort[0].Selector);
             Assert.True(opts.Sort[0].Desc);
+            Assert.Equal("g", opts.Group[0].Selector);
             Assert.Equal(new[] { "foo", "bar" }, opts.Filter.Cast<string>());
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -80,6 +80,33 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(2, g2.key);
             Assert.Same(data[0], g2.items[0]);
         }
+
+        [Fact]
+        public void Load_GroupWithOtherOptions() {
+            var data = new[] {
+                new { g = "g2", a = 1 },
+                new { g = "g2", a = 2 }, // filtered
+                new { g = "g2", a = 3 },
+                new { g = "g1", a = 0 }  // skipped
+            };
+
+            var result = (IDictionary)DataSourceLoader.Load(data, new SampleLoadOptions {
+                Filter = new[] { "a", "<>", "2" },
+                Sort = new[] { new SortingInfo { Selector = "a", Desc = true } },
+                Group = new[] { new GroupingInfo { Selector = "g" } },
+                Skip = 1,
+                Take = 1,
+                RequireTotalCount = true
+            });
+
+            Assert.Equal(3, result["totalCount"]);
+
+            var groups = (result["data"] as IEnumerable<DevExtremeGroup>).ToArray();
+            Assert.Equal(1, groups.Length);
+            Assert.Equal(2, groups[0].items.Count);
+            Assert.Same(data[2], groups[0].items[0]);
+            Assert.Same(data[0], groups[0].items[1]);
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -56,6 +56,30 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(4, result["totalCount"]);
             Assert.Equal(new[] { 3, 4 }, result["data"] as IEnumerable<int>);
         }
+
+        [Fact]
+        public void Load_GroupOnly() {
+            var data = new[] {
+                new {
+                    G1 = 1,
+                    G2 = 2
+                }
+            };
+
+            var result = DataSourceLoader.Load(data, new SampleLoadOptions {
+                Group = new[] {
+                    new GroupingInfo { Selector = "G1" },
+                    new GroupingInfo { Selector = "G2" }
+                }
+            });
+
+            var g1 = (result as IEnumerable<DevExtremeGroup>).First();
+            var g2 = g1.items[0] as DevExtremeGroup;
+
+            Assert.Equal(1, g1.key);
+            Assert.Equal(2, g2.key);
+            Assert.Same(data[0], g2.items[0]);
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/GroupHelperTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/GroupHelperTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class GroupHelperTests {
+
+        static GroupHelper<T> CreateHelper<T>(IEnumerable<T> data) {
+            return new GroupHelper<T>(data);
+        }
+
+        [Fact]
+        public void TwoLevelGrouping() {
+            var item_15_1_1 = new {
+                Year = 2015,
+                Q = 1
+            };
+
+            var item_15_1_2 = new {
+                Year = 2015,
+                Q = 1
+            };
+
+            var item_15_2_1 = new {
+                Year = 2015,
+                Q = 2
+            };
+
+            var item_16_1_1 = new {
+                Year = 2016,
+                Q = 1
+            };
+
+            var data = new[] {
+                item_15_1_1,
+                item_16_1_1,
+                item_15_2_1,
+                item_15_1_2
+            };
+
+            var helper = CreateHelper(data);
+            var groups = helper.Group("Year", "Q");
+
+            Assert.Equal(2015, groups[0].key);
+            Assert.Equal(2016, groups[1].key);
+
+            var g_2015_1 = groups[0].items[0] as DevExtremeGroup;
+            var g_2015_2 = groups[0].items[1] as DevExtremeGroup;
+            var g_2016_1 = groups[1].items[0] as DevExtremeGroup;
+
+            Assert.Equal(1, g_2015_1.key);
+            Assert.Equal(2, g_2015_2.key);
+            Assert.Equal(1, g_2016_1.key);
+
+            Assert.Same(item_15_1_1, g_2015_1.items[0]);
+            Assert.Same(item_15_1_2, g_2015_1.items[1]);
+            Assert.Same(item_15_2_1, g_2015_2.items[0]);
+            Assert.Same(item_16_1_1, g_2016_1.items[0]);
+        }
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -52,11 +52,13 @@ namespace DevExtreme.AspNet.Data {
                 if(Sort != null)
                     body = new SortExpressionCompiler<T>().Compile(body, GetFullSort());
 
-                if(Skip > 0)
-                    body = Expression.Call(queryableType, "Skip", genericTypeArguments, body, Expression.Constant(Skip));
+                if(!HasGroups) {
+                    if(Skip > 0)
+                        body = Expression.Call(queryableType, "Skip", genericTypeArguments, body, Expression.Constant(Skip));
 
-                if(Take > 0)
-                    body = Expression.Call(queryableType, "Take", genericTypeArguments, body, Expression.Constant(Take));
+                    if(Take > 0)
+                        body = Expression.Call(queryableType, "Take", genericTypeArguments, body, Expression.Constant(Take));
+                }
             }
 
             if(isCountQuery)

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -15,8 +15,12 @@ namespace DevExtreme.AspNet.Data {
         public SortingInfo[] Sort { get; set; }
         public GroupingInfo[] Group { get; set; }
 
-        bool HasGroups {
+        public bool HasGroups {
             get { return Group != null && Group.Length > 0; }
+        }
+
+        public string[] GetGroupSelectors() {
+            return Group.Select(i => i.Selector).ToArray();
         }
 
         public LambdaExpression Build(bool isCountQuery) {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -12,6 +12,7 @@ namespace DevExtreme.AspNet.Data {
         public int Skip { get; set; }
         public int Take { get; set; }
         public SortingInfo[] Sort { get; set; }
+        public GroupingInfo[] Group { get; set; }
         public IList Filter { get; set; }
     }
 

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -11,7 +11,8 @@ namespace DevExtreme.AspNet.Data {
                 Skip = options.Skip,
                 Take = options.Take,
                 Filter = options.Filter,
-                Sort = options.Sort
+                Sort = options.Sort,
+                Group = options.Group
             };
 
             var q = source.AsQueryable();
@@ -20,6 +21,10 @@ namespace DevExtreme.AspNet.Data {
                 return builder.Build(true).Compile().DynamicInvoke(q);
 
             var data = builder.Build(false).Compile().DynamicInvoke(q);
+
+            if(builder.HasGroups) {
+                data = new GroupHelper<T>((IEnumerable<T>)data).Group(builder.GetGroupSelectors());
+            }
 
             if(options.RequireTotalCount)
                 return new Dictionary<string, object> {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -20,13 +20,7 @@ namespace DevExtreme.AspNet.Data {
             if(options.IsCountQuery)
                 return builder.BuildCountExpr().Compile()(q);
 
-            var loadResult = builder.BuildLoadExpr().Compile()(q);
-
-            object data = null;
-            if(builder.HasGroups)
-                data = new GroupHelper<T>(loadResult).Group(builder.GetGroupSelectors());
-            else
-                data = loadResult;
+            object data = LoadData(builder, q);
 
             if(options.RequireTotalCount)
                 return new Dictionary<string, object> {
@@ -35,6 +29,22 @@ namespace DevExtreme.AspNet.Data {
                 };
 
             return data;
+        }
+
+        static object LoadData<T>(DataSourceExpressionBuilder<T> builder, IQueryable<T> q) {
+            var loadResult = builder.BuildLoadExpr().Compile()(q);
+            if(!builder.HasGroups)
+                return loadResult;
+
+            IEnumerable<DevExtremeGroup> groups = new GroupHelper<T>(loadResult).Group(builder.GetGroupSelectors());
+
+            if(builder.Skip > 0)
+                groups = groups.Skip(builder.Skip);
+
+            if(builder.Take > 0)
+                groups = groups.Take(builder.Take);
+
+            return groups;
         }
 
     }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -18,18 +18,20 @@ namespace DevExtreme.AspNet.Data {
             var q = source.AsQueryable();
 
             if(options.IsCountQuery)
-                return builder.Build(true).Compile().DynamicInvoke(q);
+                return builder.BuildCountExpr().Compile()(q);
 
-            var data = builder.Build(false).Compile().DynamicInvoke(q);
+            var loadResult = builder.BuildLoadExpr().Compile()(q);
 
-            if(builder.HasGroups) {
-                data = new GroupHelper<T>((IEnumerable<T>)data).Group(builder.GetGroupSelectors());
-            }
+            object data = null;
+            if(builder.HasGroups)
+                data = new GroupHelper<T>(loadResult).Group(builder.GetGroupSelectors());
+            else
+                data = loadResult;
 
             if(options.RequireTotalCount)
                 return new Dictionary<string, object> {
-                    { "data", data  },
-                    { "totalCount",  builder.Build(true).Compile().DynamicInvoke(q) }
+                    { "data", data },
+                    { "totalCount", builder.BuildCountExpr().Compile()(q) }
                 };
 
             return data;

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -38,6 +38,10 @@ namespace DevExtreme.AspNet.Data {
             return Expression.Convert(expr, type);
         }
 
+        protected ParameterExpression CreateItemParam(Type type) {
+            return Expression.Parameter(type, "obj");
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -13,7 +13,7 @@ namespace DevExtreme.AspNet.Data {
     class FilterExpressionCompiler<T> : ExpressionCompiler {
 
         public virtual LambdaExpression Compile(IList criteriaJson) {
-            var dataItemExpr = Expression.Parameter(typeof(T), "obj");
+            var dataItemExpr = CreateItemParam(typeof(T));
             return Expression.Lambda(CompileCore(dataItemExpr, criteriaJson), dataItemExpr);
         }
 

--- a/net/DevExtreme.AspNet.Data/GroupHelper.cs
+++ b/net/DevExtreme.AspNet.Data/GroupHelper.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace DevExtreme.AspNet.Data {
+
+    class DevExtremeGroup {
+        public object key;
+        public IList<object> items;
+    }
+
+
+    class GroupHelper<T> : ExpressionCompiler {
+        IDictionary<string, Func<T, object>> _accessors = new Dictionary<string, Func<T, object>>();
+        IEnumerable<T> _data;
+
+        public GroupHelper(IEnumerable<T> data) {
+            _data = data;
+        }
+
+        public IList<DevExtremeGroup> Group(params string[] selectors) {
+            return Group(_data, selectors);
+        }
+
+        IList<DevExtremeGroup> Group(IEnumerable<T> data, IEnumerable<string> selectors) {
+            var groups = Group(data, selectors.First());
+
+            if(selectors.Count() > 1) {
+                groups = groups
+                    .Select(g => new DevExtremeGroup {
+                        key = g.key,
+                        items = Group(g.items.Cast<T>(), selectors.Skip(1))
+                            .Cast<object>()
+                            .ToArray()
+                    })
+                    .ToArray();
+            }
+
+            return groups;
+        }
+
+
+        IList<DevExtremeGroup> Group(IEnumerable<T> data, string selector) {
+            var map = new Dictionary<object, DevExtremeGroup>();
+            var groups = new List<DevExtremeGroup>();
+
+            foreach(var item in data) {
+                var key = GetMember(item, selector);
+                if(!map.ContainsKey(key)) {
+                    var group = new DevExtremeGroup {
+                        key = key,
+                        items = new List<object>()
+                    };
+                    map[key] = group;
+                    groups.Add(group);
+                }
+                map[key].items.Add(item);
+            }
+
+            return groups;
+        }
+
+
+        object GetMember(T obj, string name) {
+            if(!_accessors.ContainsKey(name)) {
+                var param = CreateItemParam(typeof(T));
+
+                _accessors[name] = Expression.Lambda<Func<T, object>>(
+                    Expression.Convert(CompileAccessorExpression(param, name), typeof(Object)),
+                    param
+                ).Compile();
+            }
+
+            return _accessors[name](obj);
+        }
+
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/GroupingInfo.cs
+++ b/net/DevExtreme.AspNet.Data/GroupingInfo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DevExtreme.AspNet.Data {
+
+    public class GroupingInfo : SortingInfo {
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/Helpers/DataSourceLoadOptionsParser.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DataSourceLoadOptionsParser.cs
@@ -14,6 +14,7 @@ namespace DevExtreme.AspNet.Data.Helpers {
             KEY_SKIP = "skip",
             KEY_TAKE = "take",
             KEY_SORT = "sort",
+            KEY_GROUP = "group",
             KEY_FILTER = "filter";
 
         public static void Parse(DataSourceLoadOptionsBase loadOptions, Func<string, string> valueSource) {
@@ -22,6 +23,7 @@ namespace DevExtreme.AspNet.Data.Helpers {
             var skip = valueSource(KEY_SKIP);
             var take = valueSource(KEY_TAKE);
             var sort = valueSource(KEY_SORT);
+            var group = valueSource(KEY_GROUP);
             var filter = valueSource(KEY_FILTER);
 
             if(!String.IsNullOrEmpty(requireTotalCount))
@@ -38,6 +40,9 @@ namespace DevExtreme.AspNet.Data.Helpers {
 
             if(!String.IsNullOrEmpty(sort))
                 loadOptions.Sort = JsonConvert.DeserializeObject<SortingInfo[]>(sort);
+
+            if(!String.IsNullOrEmpty(group))
+                loadOptions.Group = JsonConvert.DeserializeObject<GroupingInfo[]>(group);
 
             if(!String.IsNullOrEmpty(filter))
                 loadOptions.Filter = JsonConvert.DeserializeObject<IList>(filter);

--- a/net/DevExtreme.AspNet.Data/SortExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/SortExpressionCompiler.cs
@@ -9,7 +9,7 @@ namespace DevExtreme.AspNet.Data {
     class SortExpressionCompiler<T> : ExpressionCompiler {
 
         public virtual Expression Compile(Expression target, SortingInfo[] clientExprList) {
-            var dataItemExpr = Expression.Parameter(typeof(T), "obj");
+            var dataItemExpr = CreateItemParam(typeof(T));
             var first = true;
 
             foreach(var item in clientExprList) {

--- a/net/DevExtreme.AspNet.Data/SortExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/SortExpressionCompiler.cs
@@ -8,7 +8,7 @@ namespace DevExtreme.AspNet.Data {
 
     class SortExpressionCompiler<T> : ExpressionCompiler {
 
-        public virtual Expression Compile(Expression target, SortingInfo[] clientExprList) {
+        public virtual Expression Compile(Expression target, IEnumerable<SortingInfo> clientExprList) {
             var dataItemExpr = CreateItemParam(typeof(T));
             var first = true;
 

--- a/net/Sample/Controllers/HomeController.cs
+++ b/net/Sample/Controllers/HomeController.cs
@@ -17,5 +17,10 @@ namespace Sample.Controllers {
             return View();
         }
 
+        [Route("GroupedList")]
+        public IActionResult GroupedList() {
+            return View();
+        }
+
     }
 }

--- a/net/Sample/Controllers/NorthwindController.cs
+++ b/net/Sample/Controllers/NorthwindController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNet.Mvc;
 using Sample.Models;
 using DevExtreme.AspNet.Data;
 using Newtonsoft.Json;
+using Microsoft.Data.Entity;
 
 namespace Sample.Controllers {
 
@@ -83,7 +84,10 @@ namespace Sample.Controllers {
 
         [HttpGet("products")]
         public object Products(DataSourceLoadOptions loadOptions) {
-            return DataSourceLoader.Load(_nwind.Products, loadOptions);
+            return DataSourceLoader.Load(
+                _nwind.Products.Include(p => p.Category), 
+                loadOptions
+            );
         }
 
     }

--- a/net/Sample/Models/Category.cs
+++ b/net/Sample/Models/Category.cs
@@ -1,0 +1,29 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Sample.Models {
+
+    [Table("Categories")]
+    public partial class Category {
+        public Category() {
+            Products = new HashSet<Product>();
+        }
+
+        [Key]
+        public int CategoryID { get; set; }
+        [Required]
+        [MaxLength(15)]
+        public string CategoryName { get; set; }
+        public string Description { get; set; }
+
+        [JsonIgnore]
+        public byte[] Picture { get; set; }
+
+        [JsonIgnore]
+        [InverseProperty("Category")]
+        public virtual ICollection<Product> Products { get; set; }
+    }
+}

--- a/net/Sample/Models/NorthwindContext.cs
+++ b/net/Sample/Models/NorthwindContext.cs
@@ -8,6 +8,14 @@ namespace Sample.Models {
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder) {
+            modelBuilder.Entity<Category>(entity => {
+                entity.HasIndex(e => e.CategoryName).HasName("CategoryName");
+
+                entity.Property(e => e.Description).HasColumnType("ntext");
+
+                entity.Property(e => e.Picture).HasColumnType("image");
+            });
+
             modelBuilder.Entity<Order_Details>(entity => {
                 entity.HasKey(e => new { e.OrderID, e.ProductID });
 
@@ -35,6 +43,7 @@ namespace Sample.Models {
             });
         }
 
+        public virtual DbSet<Category> Categories { get; set; }
         public virtual DbSet<Customer> Customers { get; set; }
         public virtual DbSet<Order_Details> Order_Details { get; set; }
         public virtual DbSet<Order> Orders { get; set; }

--- a/net/Sample/Models/Product.cs
+++ b/net/Sample/Models/Product.cs
@@ -30,5 +30,9 @@ namespace Sample.Models {
         [JsonIgnore]
         [InverseProperty("Product")]
         public virtual ICollection<Order_Details> Order_Details { get; set; }
+
+        [ForeignKey("CategoryID")]
+        [InverseProperty("Products")]
+        public virtual Category Category { get; set; }
     }
 }

--- a/net/Sample/Views/Home/GroupedList.cshtml
+++ b/net/Sample/Views/Home/GroupedList.cshtml
@@ -1,0 +1,24 @@
+﻿@{
+    Layout = "~/Views/_Layout.cshtml";
+}
+
+<div id="list"></div>
+<script>
+    $(function() {
+        $("#list").dxList({
+            dataSource: {
+                store: DevExpress.data.AspNet.createStore({
+                    loadUrl: "@Url.Action("Products", "Northwind")"
+                }),
+                group: "Category.CategoryName",
+                sort: "ProductName",
+                paginate: true,
+                pageSize: 1 // group
+            },
+            grouped: true,
+            itemTemplate: function(product) {
+                return product.ProductName;
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
This PR adds support for grouping per [Data Layer Grouping docs](http://js.devexpress.com/Documentation/Guide/Data_Layer/Data_Layer/?version=15_2#Data_Layer_Data_Layer_Reading_Data_Grouping). Unit tests and sample page (grouped dxList) included.

Along the way, I got rid of `DynamicInvoke` in favor of typed delegates.

**Implementation notes.** 

Grouping is performed in-memory, on pre-filtered and pre-sorted sequence. Actually, the algorithm is a replica of DevExtreme's `multiLevelGroup` utility. 

Translation of grouping to `Queryable.GroupBy` is complicated by the need to generate anonymous classes in runtime (see http://stackoverflow.com/questions/606104), so I left this for possible future improvements.

Also this PR doesn't satisfy dxDataGrid requirements described in [Advanced Remote Operations](http://js.devexpress.com/Documentation/Guide/UI_Widgets/Data_Grid/Use_Custom_Store/?version=15_2#UI_Widgets_Data_Grid_Use_Custom_Store_Remote_Operations_Advanced_Remote_Operations).

@Seteh @San4es @IlyaKhD please review
