### PR TITLE
Query improvements

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -56,10 +55,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 new { G1 = 2, G2 = 2, A = 6, B = 11 },
             };
 
-            var expressionsBuilt = new List<string>();
-
             var loadOptions = new SampleLoadOptions {
-                ExpressionWatcher = x => expressionsBuilt.Add(x.ToString()),
                 RemoteGrouping = true,
                 RequireTotalCount = true,
                 Group = new[] {
@@ -80,8 +76,8 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             var result = (DataSourceLoadResult)DataSourceLoader.Load(data, loadOptions);
 
-            Assert.Equal(1, expressionsBuilt.Count);
-            Assert.Contains("RemoteGroupKey`8(K0 = obj.G1, K1 = obj.G2)", expressionsBuilt[0]);
+            Assert.Equal(1, loadOptions.ExpressionLog.Count);
+            Assert.Contains("RemoteGroupKey`8(K0 = obj.G1, K1 = obj.G2)", loadOptions.ExpressionLog[0]);
 
             Assert.Equal(new object[] { 6, 36M, 6M }, result.summary);
             Assert.Equal(6, result.totalCount);
@@ -128,10 +124,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 new { a = 3 }
             };
 
-            var expressionsBuilt = new List<string>();
-
-            var result = (DataSourceLoadResult)DataSourceLoader.Load(data, new SampleLoadOptions {
-                ExpressionWatcher = x => expressionsBuilt.Add(x.ToString()),
+            var loadOptions = new SampleLoadOptions {
                 RemoteGrouping = true,
                 RequireTotalCount = true,
                 Filter = new[] { "a", "<>", "2" },
@@ -140,16 +133,18 @@ namespace DevExtreme.AspNet.Data.Tests {
                 },
                 Skip = 1,
                 Take = 1
-            });
+            };
 
-            Assert.Equal(2, expressionsBuilt.Count);
+            var result = (DataSourceLoadResult)DataSourceLoader.Load(data, loadOptions);
+
+            Assert.Equal(2, loadOptions.ExpressionLog.Count);
 
             // 1 - load paged data
-            Assert.Contains("Skip", expressionsBuilt[0]);
-            Assert.Contains("Take", expressionsBuilt[0]);
+            Assert.Contains("Skip", loadOptions.ExpressionLog[0]);
+            Assert.Contains("Take", loadOptions.ExpressionLog[0]);
 
             // 2 - load summaries
-            Assert.Contains("RemoteGroupKey`8()", expressionsBuilt[1]);
+            Assert.Contains("RemoteGroupKey`8()", loadOptions.ExpressionLog[1]);
 
             Assert.Equal(4M, result.summary[0]);
             Assert.Equal(1, result.data.Cast<object>().Count());
@@ -164,18 +159,17 @@ namespace DevExtreme.AspNet.Data.Tests {
                 new { a = 3 }
             };
 
-            var expressionsBuilt = new List<string>();
-
-            var result = (DataSourceLoadResult)DataSourceLoader.Load(data, new SampleLoadOptions {
-                ExpressionWatcher = x => expressionsBuilt.Add(x.ToString()),
+            var loadOptions = new SampleLoadOptions {
                 RemoteGrouping = true,
                 RequireTotalCount = true,
                 Filter = new[] { "a", "<>", "2" },
                 Skip = 1,
                 Take = 1
-            });
+            };
 
-            Assert.False(expressionsBuilt.Any(i => i.Contains("RemoteGroupKey")));
+            var result = (DataSourceLoadResult)DataSourceLoader.Load(data, loadOptions);
+
+            Assert.False(loadOptions.ExpressionLog.Any(i => i.Contains("RemoteGroupKey")));
 
             Assert.Equal(2, result.totalCount);
             Assert.Null(result.summary);

--- a/net/DevExtreme.AspNet.Data.Tests/SampleLoadOptions.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SampleLoadOptions.cs
@@ -6,9 +6,11 @@ using System.Threading.Tasks;
 namespace DevExtreme.AspNet.Data.Tests {
 
     class SampleLoadOptions : DataSourceLoadOptionsBase {
+        public List<string> ExpressionLog = new List<string>();
 
         public SampleLoadOptions() {
             UseQueryableOnce = true;
+            ExpressionWatcher = x => ExpressionLog.Add(x.ToString());
         }
 
     }

--- a/net/DevExtreme.AspNet.Data.Tests/SampleLoadOptions.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SampleLoadOptions.cs
@@ -6,6 +6,11 @@ using System.Threading.Tasks;
 namespace DevExtreme.AspNet.Data.Tests {
 
     class SampleLoadOptions : DataSourceLoadOptionsBase {
+
+        public SampleLoadOptions() {
+            UseQueryableOnce = true;
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -69,9 +69,6 @@ namespace DevExtreme.AspNet.Data {
             if(isCountQuery)
                 body = Expression.Call(queryableType, "Count", genericTypeArguments, body);
 
-            if(_loadOptions.ExpressionWatcher != null)
-                _loadOptions.ExpressionWatcher(body);
-
             return body;
         }
 

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -23,6 +23,7 @@ namespace DevExtreme.AspNet.Data {
 
 #if DEBUG
         internal Action<Expression> ExpressionWatcher;
+        internal bool UseQueryableOnce;
 #endif
 
         internal bool HasGroups {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -21,7 +21,9 @@ namespace DevExtreme.AspNet.Data {
         public bool? RemoteGrouping;
         public string DefaultSort;
 
+#if DEBUG
         internal Action<Expression> ExpressionWatcher;
+#endif
 
         internal bool HasGroups {
             get { return Group != null && Group.Length > 0; }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -53,7 +53,7 @@ namespace DevExtreme.AspNet.Data {
                         result.totalCount = builder.BuildCountExpr().Compile()(queryableSource);
 
                     if(options.HasSummary) {
-                        data = EnsureBuffered<T>(data);
+                        data = Buffer<T>(data);
                         result.summary = new AggregateCalculator<T>(data, accessor, options.TotalSummary, options.GroupSummary).Run();
                     }
                 }
@@ -73,7 +73,7 @@ namespace DevExtreme.AspNet.Data {
             return result;
         }
 
-        static IEnumerable EnsureBuffered<T>(IEnumerable data) {
+        static IEnumerable Buffer<T>(IEnumerable data) {
             var q = data as IQueryable<T>;
             if(q != null)
                 return q.ToArray();

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -85,7 +85,8 @@ namespace DevExtreme.AspNet.Data {
             var result = query(source);
 
 #if DEBUG
-            result = new QueryableOnce<R>(result);
+            if(options.UseQueryableOnce)
+                result = new QueryableOnce<R>(result);
 
             if(options.ExpressionWatcher != null)
                 options.ExpressionWatcher(result.Expression);            

--- a/net/DevExtreme.AspNet.Data/QueryableOnce.cs
+++ b/net/DevExtreme.AspNet.Data/QueryableOnce.cs
@@ -1,0 +1,51 @@
+﻿#if DEBUG
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace DevExtreme.AspNet.Data {
+
+    class QueryableOnce<T> : IQueryable<T> {
+        IQueryable<T> _source;
+        bool _enumerated;
+
+        public QueryableOnce(IQueryable<T> source) {
+            _source = source;
+        }
+
+        Type IQueryable.ElementType {
+            get { return _source.ElementType; }
+        }
+
+        Expression IQueryable.Expression {
+            get { return _source.Expression; }
+        }
+
+        IQueryProvider IQueryable.Provider {
+            get { throw new NotSupportedException(); }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        IEnumerator<T> GetEnumerator() {
+            if(_enumerated)
+                throw new InvalidOperationException("Query already enumerated");
+
+            _enumerated = true;
+
+            foreach(var i in _source)
+                yield return i;
+        }
+    }
+
+}
+#endif


### PR DESCRIPTION
1. In unit tests, generated queries are wrapped in `QueryableOnce`, to ensure that `DataSourceLoader` never executes a query repeatedly.

2. Query execution is delayed as much as possible.

3. 1 & 2 together guarantee (provided good test coverage) that `GroupHelper`, `AggregateCalculator` and `RemoteGroupTransformer` don't involve multiple enumerations, except special cases when explicit `EnsureBuffered` call is required.

4. The use of `ExpressionWatcher` moved to a more appropriate place.