### PR TITLE
fix unary operation detection

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
@@ -143,6 +143,13 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
+        public void IsUnaryWithJsonCriteria() {
+            var crit = JsonConvert.DeserializeObject<IList>("[\"!\", []]");
+            var compiler = new FilterExpressionCompiler<object>(false);
+            Assert.True(compiler.IsUnary(crit));
+        }
+
+        [Fact]
         public void GroupOfMany() {
             var crit = new object[] {
                 new object[] { "IntProp", ">", 1 },

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -172,8 +172,8 @@ namespace DevExtreme.AspNet.Data {
             return item is IList && !(item is String);
         }
 
-        bool IsUnary(IList criteriaJson) {
-            return Equals(criteriaJson[0], "!");
+        internal bool IsUnary(IList criteriaJson) {
+            return Convert.ToString(criteriaJson[0]) == "!";
         }
 
     }


### PR DESCRIPTION
use Convert.ToString instead of Equals because JSON deserializer wraps strings in JValue