### PR TITLE
Resolve #82

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/AddRequiredSortTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/AddRequiredSortTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class AddRequiredSortTests {
+
+        [Fact]
+        public void Deduplicate() {
+            var sort = Utils.AddRequiredSort(
+                new[] {
+                    new SortingInfo { Selector = "A" },
+                    new SortingInfo { Selector = "B" }
+                },
+                new[] { "A", "C" }
+            );
+
+            Assert.Equal(new[] { "A", "B", "C" }, sort.Select(i => i.Selector));
+        }
+
+        [Fact]
+        public void Desc() {
+            var initalSort = new[] {
+                new SortingInfo {
+                    Selector = "A",
+                    Desc = false
+                }
+            };
+            var requiredSelectors = new[] { "R1", "R2" };
+            
+            var ensuredSort = Utils.AddRequiredSort(initalSort, requiredSelectors).ToArray();
+            Assert.False(ensuredSort[1].Desc);
+            Assert.False(ensuredSort[2].Desc);
+
+            initalSort[0].Desc = true;
+            ensuredSort = Utils.AddRequiredSort(initalSort, requiredSelectors).ToArray();
+            Assert.True(ensuredSort[1].Desc);
+            Assert.True(ensuredSort[2].Desc);
+        }
+
+        [Fact]
+        public void InitialSortIsNull() {
+            var sort = Utils.AddRequiredSort(null, new[] { "R" });
+            Assert.Equal("R", sort.First().Selector);
+        }
+
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -197,6 +197,30 @@ namespace DevExtreme.AspNet.Data.Tests {
                 builder.BuildLoadExpr().Body.ToString()
             );
         }
+
+        [Fact]
+        public void DefaultSortAndPrimaryKey() {
+            var options = new SampleLoadOptions {
+                PrimaryKey = new[] { "Item1" },
+                DefaultSort = "Item1",
+                Sort = new[] { new SortingInfo { Selector = "Item1" } }
+            };
+
+            var builder = new DataSourceExpressionBuilder<Tuple<int, int, int>>(options, false);
+
+            Assert.Equal(
+                "data.OrderBy(obj => obj.Item1)",
+                builder.BuildLoadExpr().Body.ToString()
+            );
+
+            options.DefaultSort = "Item2";
+            options.Sort[0].Selector = "Item3";
+
+            Assert.Equal(
+                "data.OrderBy(obj => obj.Item3).ThenBy(obj => obj.Item2).ThenBy(obj => obj.Item1)",
+                builder.BuildLoadExpr().Body.ToString()
+            );
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -149,7 +149,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         [Fact]
         public void DefaultSort() {
             var options = new SampleLoadOptions {
-                DefaultSort = "Item1"
+                ObsoleteDefaultSort = "Item1"
             };
 
             var builder = new DataSourceExpressionBuilder<Tuple<int, int>>(options, false);

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -160,7 +160,10 @@ namespace DevExtreme.AspNet.Data.Tests {
                 new SortingInfo { Selector = "Item2" }
             };
 
-            Assert.Equal("data.OrderBy(obj => obj.Item2)", builder.BuildLoadExpr(false).Body.ToString());
+            Assert.Equal("data.OrderBy(obj => obj.Item2).ThenBy(obj => obj.Item1)", builder.BuildLoadExpr(false).Body.ToString());
+
+            options.Sort[0].Selector = "Item1";
+            Assert.Equal("data.OrderBy(obj => obj.Item1)", builder.BuildLoadExpr(false).Body.ToString());
         }
 
         [Fact]

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -180,6 +180,20 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             Assert.True(expr.StartsWith("data.GroupBy"));
         }
+
+        [Fact]
+        public void AlwaysOrderDataByPrimaryKey() {
+            var options = new SampleLoadOptions {
+                PrimaryKey = new[] { "Item2", "Item1" }
+            };
+
+            var builder = new DataSourceExpressionBuilder<Tuple<int, int>>(options, false);
+
+            Assert.Equal(
+                "data.OrderBy(obj => obj.Item2).ThenBy(obj => obj.Item1)",
+                builder.BuildLoadExpr().Body.ToString()
+            );
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -149,7 +149,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         [Fact]
         public void DefaultSort() {
             var options = new SampleLoadOptions {
-                ObsoleteDefaultSort = "Item1"
+                DefaultSort = "Item1"
             };
 
             var builder = new DataSourceExpressionBuilder<Tuple<int, int>>(options, false);

--- a/net/DevExtreme.AspNet.Data.Tests/EFSortingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/EFSortingTests.cs
@@ -21,13 +21,6 @@ namespace DevExtreme.AspNet.Data.Tests {
             public object Bad6 { get; set; }
         }
 
-        class TestClass_KeyAttr : TestClass_Base {
-            public int Skip { get; set; }
-
-            [System.ComponentModel.DataAnnotations.Key]
-            public int Key { get; set; }
-        }
-
         class TestClass_LikelyKey : TestClass_Base {
             public DateTime Skip { get; set; }
             public Guid Key { get; set; }
@@ -49,7 +42,6 @@ namespace DevExtreme.AspNet.Data.Tests {
         [Fact]
         public void FindSortableMember() {
             Assert.Null(EFSorting.FindSortableMember(typeof(TestClass_Base)));
-            Assert.Equal("Key", EFSorting.FindSortableMember(typeof(TestClass_KeyAttr)));
             Assert.Equal("Key", EFSorting.FindSortableMember(typeof(TestClass_LikelyKey)));
             Assert.Equal("Key", EFSorting.FindSortableMember(typeof(TestClass_Field)));
             Assert.Equal("Sortable", EFSorting.FindSortableMember(typeof(TestClass_OtherSortable)));

--- a/net/DevExtreme.AspNet.Data.Tests/EFSortingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/EFSortingTests.cs
@@ -38,6 +38,20 @@ namespace DevExtreme.AspNet.Data.Tests {
             public int? Sortable { get; set; }
         }
 
+        class TestClass_CodeFirstConv1 {
+            public int NotAKey { get; set; }
+            public int ID { get; set; }
+        }
+
+        class TestClass_CodeFirstConv2 {
+            public int NotAKey { get; set; }
+            public int TestClass_CodeFirstConv2Id { get; set; }
+        }
+
+        class TestClass_CodeFirstConv_InvalidType {
+            public byte[] ID { get; set; }
+        }
+
 
         [Fact]
         public void FindSortableMember() {
@@ -46,6 +60,11 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal("Key", EFSorting.FindSortableMember(typeof(TestClass_Field)));
             Assert.Equal("Sortable", EFSorting.FindSortableMember(typeof(TestClass_OtherSortable)));
             Assert.Equal("Sortable", EFSorting.FindSortableMember(typeof(TestClass_Nullable)));
+
+            // see https://msdn.microsoft.com/en-us/library/jj679962(v=vs.113).aspx#Anchor_1
+            Assert.Equal("ID", EFSorting.FindSortableMember(typeof(TestClass_CodeFirstConv1)));
+            Assert.Equal("TestClass_CodeFirstConv2Id", EFSorting.FindSortableMember(typeof(TestClass_CodeFirstConv2)));
+            Assert.Null(EFSorting.FindSortableMember(typeof(TestClass_CodeFirstConv_InvalidType)));
         }
 
 

--- a/net/DevExtreme.AspNet.Data.Tests/UtilsTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/UtilsTests.cs
@@ -6,10 +6,12 @@ using Xunit;
 
 namespace DevExtreme.AspNet.Data.Tests {
 
-    public class AddRequiredSortTests {
+    public class UtilsTests {
+
+        // AddRequiredSort
 
         [Fact]
-        public void Deduplicate() {
+        public void AddRequiredSort_Deduplicate() {
             var sort = Utils.AddRequiredSort(
                 new[] {
                     new SortingInfo { Selector = "A" },
@@ -22,7 +24,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
-        public void Desc() {
+        public void AddRequiredSort_Desc() {
             var initalSort = new[] {
                 new SortingInfo {
                     Selector = "A",
@@ -42,11 +44,33 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
-        public void InitialSortIsNull() {
+        public void AddRequiredSort_InitialSortIsNull() {
             var sort = Utils.AddRequiredSort(null, new[] { "R" });
             Assert.Equal("R", sort.First().Selector);
         }
 
+        // GetPrimaryKey
+
+        class ClassWithMultiplePK {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int Z;
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public int A { get; set; }
+        }
+
+        [Fact]
+        public void GetPrimaryKey_NoKey() {
+            Assert.Empty(Utils.GetPrimaryKey(typeof(int)));
+        }
+
+        [Fact]
+        public void GetPrimaryKey_MultiKey() {
+            Assert.Equal(
+                new[] { "A", "Z" },
+                Utils.GetPrimaryKey(typeof(ClassWithMultiplePK))
+            );
+        }
 
     }
 

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -52,7 +52,7 @@ namespace DevExtreme.AspNet.Data {
 
             if(!isCountQuery) {
                 if(!remoteGrouping) {
-                    if(_loadOptions.HasSort || _loadOptions.HasDefaultSort || _loadOptions.HasGroups || _loadOptions.HasPrimaryKey)
+                    if(_loadOptions.HasAnySort)
                         body = new SortExpressionCompiler<T>(_guardNulls).Compile(body, _loadOptions.GetFullSort());
                 } else {
                     body = new RemoteGroupExpressionCompiler<T>(_loadOptions.Group, _loadOptions.TotalSummary, _loadOptions.GroupSummary).Compile(body);

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -52,7 +52,7 @@ namespace DevExtreme.AspNet.Data {
 
             if(!isCountQuery) {
                 if(!remoteGrouping) {
-                    if(_loadOptions.HasSort || _loadOptions.HasDefaultSort || _loadOptions.HasGroups)
+                    if(_loadOptions.HasSort || _loadOptions.HasObsoleteDefaultSort || _loadOptions.HasGroups)
                         body = new SortExpressionCompiler<T>(_guardNulls).Compile(body, _loadOptions.GetFullSort());
                 } else {
                     body = new RemoteGroupExpressionCompiler<T>(_loadOptions.Group, _loadOptions.TotalSummary, _loadOptions.GroupSummary).Compile(body);

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -52,7 +52,7 @@ namespace DevExtreme.AspNet.Data {
 
             if(!isCountQuery) {
                 if(!remoteGrouping) {
-                    if(_loadOptions.HasSort || _loadOptions.HasObsoleteDefaultSort || _loadOptions.HasGroups || _loadOptions.HasPrimaryKey)
+                    if(_loadOptions.HasSort || _loadOptions.HasDefaultSort || _loadOptions.HasGroups || _loadOptions.HasPrimaryKey)
                         body = new SortExpressionCompiler<T>(_guardNulls).Compile(body, _loadOptions.GetFullSort());
                 } else {
                     body = new RemoteGroupExpressionCompiler<T>(_loadOptions.Group, _loadOptions.TotalSummary, _loadOptions.GroupSummary).Compile(body);

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -52,7 +52,7 @@ namespace DevExtreme.AspNet.Data {
 
             if(!isCountQuery) {
                 if(!remoteGrouping) {
-                    if(_loadOptions.HasSort || _loadOptions.HasObsoleteDefaultSort || _loadOptions.HasGroups)
+                    if(_loadOptions.HasSort || _loadOptions.HasObsoleteDefaultSort || _loadOptions.HasGroups || _loadOptions.HasPrimaryKey)
                         body = new SortExpressionCompiler<T>(_guardNulls).Compile(body, _loadOptions.GetFullSort());
                 } else {
                     body = new RemoteGroupExpressionCompiler<T>(_loadOptions.Group, _loadOptions.TotalSummary, _loadOptions.GroupSummary).Compile(body);

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -20,7 +20,7 @@ namespace DevExtreme.AspNet.Data {
         public SummaryInfo[] GroupSummary;
 
         public bool? RemoteGrouping;
-        public string DefaultSort;
+
 
 #if DEBUG
         internal Action<Expression> ExpressionWatcher;
@@ -33,10 +33,6 @@ namespace DevExtreme.AspNet.Data {
 
         internal bool HasSort {
             get { return Sort != null && Sort.Length > 0; }
-        }
-
-        internal bool HasDefaultSort {
-            get { return !String.IsNullOrEmpty(DefaultSort); }
         }
 
         internal bool HasSummary {
@@ -67,11 +63,27 @@ namespace DevExtreme.AspNet.Data {
                 }
             }
 
-            if(result.Count < 1 && HasDefaultSort)
-                result.Add(new SortingInfo { Selector = DefaultSort });
+            if(result.Count < 1 && HasObsoleteDefaultSort)
+                result.Add(new SortingInfo { Selector = ObsoleteDefaultSort });
 
             return result;
         }
+
+        #region Obsolete
+
+        [Obsolete("DefaultSort is obsolete. Use PrimaryKey instead.")]
+        public string DefaultSort {
+            get { return ObsoleteDefaultSort; }
+            set { ObsoleteDefaultSort = value; }
+        }
+
+        internal string ObsoleteDefaultSort;
+
+        internal bool HasObsoleteDefaultSort {
+            get { return !String.IsNullOrEmpty(ObsoleteDefaultSort); }
+        }
+
+        #endregion
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -21,6 +21,7 @@ namespace DevExtreme.AspNet.Data {
 
         public bool? RemoteGrouping;
         public string[] PrimaryKey;
+        public string DefaultSort;
 
 #if DEBUG
         internal Action<Expression> ExpressionWatcher;
@@ -37,6 +38,10 @@ namespace DevExtreme.AspNet.Data {
 
         internal bool HasPrimaryKey {
             get { return PrimaryKey != null && PrimaryKey.Length > 0; }
+        }
+
+        internal bool HasDefaultSort {
+            get { return !String.IsNullOrEmpty(DefaultSort); }
         }
 
         internal bool HasSummary {
@@ -70,27 +75,12 @@ namespace DevExtreme.AspNet.Data {
             if(HasPrimaryKey)
                 return Utils.AddRequiredSort(result, PrimaryKey);
 
-            if(result.Count < 1 && HasObsoleteDefaultSort)
-                result.Add(new SortingInfo { Selector = ObsoleteDefaultSort });
+            if(result.Count < 1 && HasDefaultSort)
+                result.Add(new SortingInfo { Selector = DefaultSort });
 
             return result;
         }
 
-        #region Obsolete
-
-        [Obsolete("DefaultSort is obsolete. Use PrimaryKey instead.")]
-        public string DefaultSort {
-            get { return ObsoleteDefaultSort; }
-            set { ObsoleteDefaultSort = value; }
-        }
-
-        internal string ObsoleteDefaultSort;
-
-        internal bool HasObsoleteDefaultSort {
-            get { return !String.IsNullOrEmpty(ObsoleteDefaultSort); }
-        }
-
-        #endregion
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -48,6 +48,10 @@ namespace DevExtreme.AspNet.Data {
             get { return TotalSummary != null && TotalSummary.Length > 0 || GroupSummary != null && GroupSummary.Length > 0; }
         }
 
+        internal bool HasAnySort {
+            get { return HasGroups || HasSort || HasPrimaryKey || HasDefaultSort; }
+        }
+
         internal IEnumerable<SortingInfo> GetFullSort() {
             var memo = new HashSet<string>();
             var result = new List<SortingInfo>();

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -79,8 +79,10 @@ namespace DevExtreme.AspNet.Data {
             if(HasPrimaryKey)
                 return Utils.AddRequiredSort(result, PrimaryKey);
 
-            if(result.Count < 1 && HasDefaultSort)
-                result.Add(new SortingInfo { Selector = DefaultSort });
+            if(HasDefaultSort) {
+                if(!result.Any(i => i.Selector == DefaultSort))
+                    result.Add(new SortingInfo { Selector = DefaultSort });
+            }
 
             return result;
         }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -76,13 +76,13 @@ namespace DevExtreme.AspNet.Data {
                 }
             }
 
-            if(HasPrimaryKey)
-                return Utils.AddRequiredSort(result, PrimaryKey);
-
             if(HasDefaultSort) {
                 if(!result.Any(i => i.Selector == DefaultSort))
                     result.Add(new SortingInfo { Selector = DefaultSort });
             }
+
+            if(HasPrimaryKey)
+                return Utils.AddRequiredSort(result, PrimaryKey);
 
             return result;
         }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -20,7 +20,7 @@ namespace DevExtreme.AspNet.Data {
         public SummaryInfo[] GroupSummary;
 
         public bool? RemoteGrouping;
-
+        public string[] PrimaryKey;
 
 #if DEBUG
         internal Action<Expression> ExpressionWatcher;
@@ -33,6 +33,10 @@ namespace DevExtreme.AspNet.Data {
 
         internal bool HasSort {
             get { return Sort != null && Sort.Length > 0; }
+        }
+
+        internal bool HasPrimaryKey {
+            get { return PrimaryKey != null && PrimaryKey.Length > 0; }
         }
 
         internal bool HasSummary {
@@ -62,6 +66,9 @@ namespace DevExtreme.AspNet.Data {
                     result.Add(s);
                 }
             }
+
+            if(HasPrimaryKey)
+                return Utils.AddRequiredSort(result, PrimaryKey);
 
             if(result.Count < 1 && HasObsoleteDefaultSort)
                 result.Add(new SortingInfo { Selector = ObsoleteDefaultSort });

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -86,7 +86,6 @@ namespace DevExtreme.AspNet.Data {
 
             return result;
         }
-
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -76,15 +76,15 @@ namespace DevExtreme.AspNet.Data {
                 }
             }
 
-            if(HasDefaultSort) {
-                if(!result.Any(i => i.Selector == DefaultSort))
-                    result.Add(new SortingInfo { Selector = DefaultSort });
-            }
+            IEnumerable<string> requiredSort = new string[0];
+
+            if(HasDefaultSort)
+                requiredSort = requiredSort.Concat(new[] { DefaultSort });
 
             if(HasPrimaryKey)
-                return Utils.AddRequiredSort(result, PrimaryKey);
+                requiredSort = requiredSort.Concat(PrimaryKey);
 
-            return result;
+            return Utils.AddRequiredSort(result, requiredSort);
         }
     }
 

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -21,17 +21,6 @@ namespace DevExtreme.AspNet.Data {
             if(options.IsCountQuery)
                 return builder.BuildCountExpr().Compile()(source);
 
-            if(Compat.IsEntityFramework(source.Provider)) {
-                if(!options.HasPrimaryKey)
-                    options.PrimaryKey = Utils.GetPrimaryKey(typeof(T));
-
-                if(!options.HasAnySort) {
-                    if(options.Skip > 0 || options.Take > 0) {
-                        options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
-                    }
-                }
-            }
-
             var accessor = new DefaultAccessor<T>();
             var result = new DataSourceLoadResult();
             var emptyGroups = options.HasGroups && !options.Group.Last().GetIsExpanded();
@@ -50,6 +39,12 @@ namespace DevExtreme.AspNet.Data {
                     result.groupCount = groupingResult.Groups.Count();
 
             } else {
+                if(!options.HasPrimaryKey)
+                    options.PrimaryKey = Utils.GetPrimaryKey(typeof(T));
+
+                if((options.Skip > 0 || options.Take > 0) && !options.HasAnySort && Compat.IsEntityFramework(source.Provider))
+                    options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
+
                 var deferPaging = options.HasGroups || options.HasSummary && !canUseRemoteGrouping;
                 var queryResult = ExecQuery(builder.BuildLoadExpr(!deferPaging).Compile(), source, options);
 

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -27,8 +27,8 @@ namespace DevExtreme.AspNet.Data {
 
                 if(!options.HasPrimaryKey) {
                     if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0)) {
-                        if(!options.HasObsoleteDefaultSort)
-                            options.ObsoleteDefaultSort = EFSorting.FindSortableMember(typeof(T));
+                        if(!options.HasDefaultSort)
+                            options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
                     }
                 }
             }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -22,8 +22,8 @@ namespace DevExtreme.AspNet.Data {
                 return builder.BuildCountExpr().Compile()(source);
 
             if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0) && Compat.IsEntityFrramework(source.Provider)) {
-                if(!options.HasDefaultSort)
-                    options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
+                if(!options.HasObsoleteDefaultSort)
+                    options.ObsoleteDefaultSort = EFSorting.FindSortableMember(typeof(T));
             }
 
             var accessor = new DefaultAccessor<T>();

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -25,10 +25,9 @@ namespace DevExtreme.AspNet.Data {
                 if(!options.HasPrimaryKey)
                     options.PrimaryKey = Utils.GetPrimaryKey(typeof(T));
 
-                if(!options.HasPrimaryKey) {
-                    if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0)) {
-                        if(!options.HasDefaultSort)
-                            options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
+                if(!options.HasAnySort) {
+                    if(options.Skip > 0 || options.Take > 0) {
+                        options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
                     }
                 }
             }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -42,7 +42,7 @@ namespace DevExtreme.AspNet.Data {
                 if(!options.HasPrimaryKey)
                     options.PrimaryKey = Utils.GetPrimaryKey(typeof(T));
 
-                if((options.Skip > 0 || options.Take > 0) && !options.HasAnySort && Compat.IsEntityFramework(source.Provider))
+                if(!options.HasPrimaryKey && (options.Skip > 0 || options.Take > 0) && Compat.IsEntityFramework(source.Provider))
                     options.DefaultSort = EFSorting.FindSortableMember(typeof(T));
 
                 var deferPaging = options.HasGroups || options.HasSummary && !canUseRemoteGrouping;

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -21,9 +21,16 @@ namespace DevExtreme.AspNet.Data {
             if(options.IsCountQuery)
                 return builder.BuildCountExpr().Compile()(source);
 
-            if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0) && Compat.IsEntityFramework(source.Provider)) {
-                if(!options.HasObsoleteDefaultSort)
-                    options.ObsoleteDefaultSort = EFSorting.FindSortableMember(typeof(T));
+            if(Compat.IsEntityFramework(source.Provider)) {
+                if(!options.HasPrimaryKey)
+                    options.PrimaryKey = Utils.GetPrimaryKey(typeof(T));
+
+                if(!options.HasPrimaryKey) {
+                    if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0)) {
+                        if(!options.HasObsoleteDefaultSort)
+                            options.ObsoleteDefaultSort = EFSorting.FindSortableMember(typeof(T));
+                    }
+                }
             }
 
             var accessor = new DefaultAccessor<T>();

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -21,7 +21,7 @@ namespace DevExtreme.AspNet.Data {
             if(options.IsCountQuery)
                 return builder.BuildCountExpr().Compile()(source);
 
-            if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0) && Compat.IsEntityFrramework(source.Provider)) {
+            if(!options.HasSort && !options.HasGroups && (options.Skip > 0 || options.Take > 0) && Compat.IsEntityFramework(source.Provider)) {
                 if(!options.HasObsoleteDefaultSort)
                     options.ObsoleteDefaultSort = EFSorting.FindSortableMember(typeof(T));
             }

--- a/net/DevExtreme.AspNet.Data/Helpers/Compat.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/Compat.cs
@@ -8,10 +8,11 @@ namespace DevExtreme.AspNet.Data.Helpers {
 
     public static class Compat {
 
-        internal static bool IsEntityFrramework(IQueryProvider provider) {
+        internal static bool IsEntityFramework(IQueryProvider provider) {
             var type = provider.GetType().FullName;
 
             return type == "System.Data.Entity.Internal.Linq.DbQueryProvider"
+                || type == "Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryProvider"
                 || type == "Microsoft.Data.Entity.Query.Internal.EntityQueryProvider";
         }
 

--- a/net/DevExtreme.AspNet.Data/Helpers/EFSorting.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/EFSorting.cs
@@ -40,7 +40,21 @@ namespace DevExtreme.AspNet.Data.Helpers {
                     .Select(i => new Candidate(i, i.FieldType))
             );
 
+            var codeFirstId = candidates.FirstOrDefault(IsEFCodeFirstConventionalKey);
+            if(codeFirstId != null)
+                return codeFirstId.Member.Name;
+
             return ORDERED_SORTABLE_TYPES.SelectMany(type => candidates.Where(c => c.Type == type)).FirstOrDefault()?.Member.Name;
+        }
+
+        static bool IsEFCodeFirstConventionalKey(Candidate candidate) {
+            var member = candidate.Member;
+            var memberName = member.Name;
+
+            if(String.Compare(memberName, "id", true) != 0 && String.Compare(memberName, member.DeclaringType.Name + "id", true) != 0)
+                return false;
+
+            return ORDERED_SORTABLE_TYPES.Contains(candidate.Type);
         }
 
     }

--- a/net/DevExtreme.AspNet.Data/Helpers/EFSorting.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/EFSorting.cs
@@ -40,15 +40,8 @@ namespace DevExtreme.AspNet.Data.Helpers {
                     .Select(i => new Candidate(i, i.FieldType))
             );
 
-            return (
-                candidates.FirstOrDefault(HasKeyAttr)
-                ?? ORDERED_SORTABLE_TYPES.SelectMany(type => candidates.Where(c => c.Type == type)).FirstOrDefault()
-            )?.Member.Name;
+            return ORDERED_SORTABLE_TYPES.SelectMany(type => candidates.Where(c => c.Type == type)).FirstOrDefault()?.Member.Name;
         }
-
-        static bool HasKeyAttr(Candidate candidate) {
-            return candidate.Member.GetCustomAttributes(true).Any(i => i.GetType().FullName == "System.ComponentModel.DataAnnotations.KeyAttribute");
-        } 
 
     }
 

--- a/net/DevExtreme.AspNet.Data/Utils.cs
+++ b/net/DevExtreme.AspNet.Data/Utils.cs
@@ -73,6 +73,16 @@ namespace DevExtreme.AspNet.Data {
             }));
         }
 
+        public static string[] GetPrimaryKey(Type type) {
+            return new MemberInfo[0]
+                .Concat(type.GetRuntimeProperties())
+                .Concat(type.GetRuntimeFields())
+                .Where(m => m.GetCustomAttributes(true).Any(i => i.GetType().Name == "KeyAttribute"))
+                .Select(m => m.Name)
+                .OrderBy(i => i)
+                .ToArray();
+        }
+
         static object UnwrapNewtonsoftValue(object value) {
             var jValue = value as JValue;
             if(jValue != null)

--- a/net/DevExtreme.AspNet.Data/Utils.cs
+++ b/net/DevExtreme.AspNet.Data/Utils.cs
@@ -61,6 +61,18 @@ namespace DevExtreme.AspNet.Data {
                 : (desc ? nameof(Queryable.ThenByDescending) : nameof(Queryable.ThenBy));
         }
 
+        public static IEnumerable<SortingInfo> AddRequiredSort(IEnumerable<SortingInfo> sort, IEnumerable<string> requiredSelectors) {
+            sort = sort ?? new SortingInfo[0];
+            requiredSelectors = requiredSelectors.Except(sort.Select(i => i.Selector));
+
+            var desc = sort.LastOrDefault()?.Desc;
+
+            return sort.Concat(requiredSelectors.Select(i => new SortingInfo {
+                Selector = i,
+                Desc = desc != null && desc.Value
+            }));
+        }
+
         static object UnwrapNewtonsoftValue(object value) {
             var jValue = value as JValue;
             if(jValue != null)


### PR DESCRIPTION
Summary:

* `DataSourceLoadOptionsBase.DefaultSort` kept for backward compatibility
* `DataSourceLoadOptionsBase.DefaultSort` is appended even if sorting is specified by the end user
* Added `DataSourceLoadOptionsBase.PrimaryKey`, which if not specified then populated automatically based on `[Key]` attributes
* Support EF Code First primary key naming conventions