### PR TITLE
Use high version number for non-tagged builds

### DIFF
--- a/build/replace-meta.ps1
+++ b/build/replace-meta.ps1
@@ -1,6 +1,6 @@
 param ([string]$build_number, [string]$tag)
 
-$meta_version_numeric = "0.0"
+$meta_version_numeric = "99.0"
 
 if ($tag -match '^v?(([.\d]+)[\w-]*)$') {
     $meta_version_full = $matches[1]

--- a/net/DevExtreme.AspNet.Data/AssemblyInfo.cs
+++ b/net/DevExtreme.AspNet.Data/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("DevExtreme.AspNet.Data.Tests")]
 #endif
 
-[assembly: AssemblyVersion("0.0")]
+[assembly: AssemblyVersion("99.0")]
 [assembly: AssemblyCompany("%meta_company%")]
 [assembly: AssemblyCopyright("%meta_copyright%")]
 [assembly: AssemblyDescription("%meta_description%")]

--- a/net/DevExtreme.AspNet.Data/project.json
+++ b/net/DevExtreme.AspNet.Data/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "0.0",
+    "version": "99.0",
 
     "authors": [ "%meta_company%" ],
     "copyright": "%meta_copyright%",


### PR DESCRIPTION
Currenty, the version of CI builds is `0.0.0.0` which makes it impossible to use them in apps

> Assembly '...' uses 'DevExtreme.AspNet.Data, Version=1.0.0.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7' which has a higher version than referenced assembly 'DevExtreme.AspNet.Data' with identity 'DevExtreme.AspNet.Data, Version=0.0.0.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7'

The use of high version numbers can be seen in other .NET projects. For example: https://github.com/xunit/xunit/blob/2.1/src/common/GlobalAssemblyInfo.cs

P.S. The following binding redirect is required for CI builds:

```xml
<dependentAssembly>
 <assemblyIdentity name="DevExtreme.AspNet.Data" publicKeyToken="982f5dab1439d0f7"/>
 <bindingRedirect oldVersion="0.0.0.0-99.0.0.0" newVersion="99.0.0.0"/>
</dependentAssembly>
```