### PR TITLE
Replace gulp with pre-build event

### DIFF
--- a/net/Sample/Sample.csproj
+++ b/net/Sample/Sample.csproj
@@ -30,4 +30,9 @@
     </None>
   </ItemGroup>
 
+  <!-- https://github.com/dotnet/sdk/issues/1055#issuecomment-292792445 -->
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="copy $(ProjectDir)\..\..\js\*.js $(ProjectDir)\wwwroot\lib" />
+  </Target>
+
 </Project>

--- a/net/Sample/gulpfile.js
+++ b/net/Sample/gulpfile.js
@@ -1,7 +1,0 @@
-﻿/// <binding BeforeBuild='copy-js' />
-
-var gulp = require('gulp');
-
-gulp.task('copy-js', function() {
-    gulp.src("../../js/*.js").pipe(gulp.dest("wwwroot/lib"));
-});

--- a/net/Sample/package.json
+++ b/net/Sample/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "Sample",
-    "devDependencies": {
-        "gulp": "3.9.0"
-    }
-}


### PR DESCRIPTION
Visual Studio tasks don't run during CI, https://stackoverflow.com/q/30766078
Could add npm script for that, however, the task is so simple that Gulp is an overkill anyway.