### PR TITLE
Fix Sample project pre-build event

### DIFF
--- a/net/Sample/Sample.csproj
+++ b/net/Sample/Sample.csproj
@@ -32,7 +32,7 @@
 
   <!-- https://github.com/dotnet/sdk/issues/1055#issuecomment-292792445 -->
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="copy $(ProjectDir)\..\..\js\*.js $(ProjectDir)\wwwroot\lib" />
+    <Exec Command="xcopy /y $(ProjectDir)\..\..\js\*.js $(ProjectDir)\wwwroot\lib\" />
   </Target>
 
 </Project>


### PR DESCRIPTION
The current code copies the script as "lib" file if the "lib" dir doesn't exist.
