### PR TITLE
Fix SUM & AVG summary calculation for cases when there's no suitable Enumerable.Sum overload

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.EF6/Bug184.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/Bug184.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Data.Entity;
+using System.Linq;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests.EF6 {
+
+    class Bug184_DataItem {
+        [Key]
+        public int ID { get; set; }
+
+        // overload exists
+        public Int32 Int32 { get; set; }
+
+        // convert required
+        public Byte? NullableByte { get; set; }
+    }
+
+    partial class TestDbContext {
+        public DbSet<Bug184_DataItem> Bug184_Data { get; set; }
+    }
+
+    public class Bug184 {
+
+        [Fact]
+        public void Scenario() {
+            TestDbContext.Exec(context => {
+                var dbSet = context.Bug184_Data;
+
+                dbSet.Add(new Bug184_DataItem { ID = 1, Int32 = 1, NullableByte = 1 });
+                dbSet.Add(new Bug184_DataItem { ID = 2, Int32 = 2, NullableByte = 2 });
+
+                context.SaveChanges();
+
+                var loadResult = DataSourceLoader.Load(dbSet, new SampleLoadOptions {
+                    TotalSummary = new[] {
+                        new SummaryInfo { SummaryType = "sum", Selector = nameof(Bug184_DataItem.Int32) },
+                        new SummaryInfo { SummaryType = "sum", Selector = nameof(Bug184_DataItem.NullableByte) }
+                    }
+                });
+
+                Assert.Equal(
+                    new object[] { 3m, 3m },
+                    loadResult.summary
+                );
+
+            });
+        }
+
+    }
+}

--- a/net/DevExtreme.AspNet.Data.Tests.EF6/DevExtreme.AspNet.Data.Tests.EF6.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/DevExtreme.AspNet.Data.Tests.EF6.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bug179.cs" />
+    <Compile Include="Bug184.cs" />
     <Compile Include="TestDbContext.cs" />
     <Compile Include="Bug112.cs" />
     <Compile Include="SampleLoadOptions.cs" />

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -168,6 +168,35 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(4m, result.summary[0]);
         }
 
+        [Fact]
+        public void T598818() {
+            var data = new[] {
+                CreateExpando(1),
+                CreateExpando(3),
+                CreateExpando(5),
+                CreateExpando(null),
+            };
+
+            var loadOptions = new SampleLoadOptions {
+                RemoteGrouping = true,
+                TotalSummary = new[] {
+                    new SummaryInfo { SummaryType = "sum", Selector = P1 },
+                    new SummaryInfo { SummaryType = "min", Selector = P1 },
+                    new SummaryInfo { SummaryType = "max", Selector = P1 },
+                    new SummaryInfo { SummaryType = "avg", Selector = P1 }
+                }
+            };
+
+            var summary = DataSourceLoader.Load(data, loadOptions).summary;
+
+            Assert.Contains(".GroupBy", loadOptions.ExpressionLog[1]);
+
+            Assert.Equal(9m, summary[0]);
+            Assert.Equal(1, summary[1]);
+            Assert.Equal(5, summary[2]);
+            Assert.Equal(3m, summary[3]);
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
@@ -234,6 +234,27 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Single(groups);
             Assert.Equal(2, result.groupCount);
         }
+
+        [Fact]
+        public void Summary_MissingOverload() {
+            // Neither of Min, Max, Sum, Average provides an overload for byte sequences
+            var data = new byte[] { 1, 3, 5 };
+
+            var loadOptions = new SampleLoadOptions {
+                RemoteGrouping = true,
+                TotalSummary = new[] { "sum", "min", "max", "avg" }
+                    .Select(i => new SummaryInfo { Selector = "this", SummaryType = i })
+                    .ToArray()
+            };
+
+            var summary = DataSourceLoader.Load(data, loadOptions).summary;
+
+            Assert.Equal(9M, summary[0]);
+            Assert.Equal((byte)1, summary[1]);
+            Assert.Equal((byte)5, summary[2]);
+            Assert.Equal(3M, summary[3]);
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
@@ -255,6 +255,64 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(3M, summary[3]);
         }
 
+        [Fact]
+        public void Summary_MissingOverload_SumBrute() {
+            var values = new[] {
+                new {
+                    p1 = byte.MaxValue,
+                    p2 = sbyte.MaxValue,
+                    p3 = short.MaxValue,
+                    p4 = ushort.MaxValue,
+                    p5 = uint.MaxValue,
+                    p6 = ulong.MaxValue
+                }
+            };
+
+            var nullableValues = new[] {
+                new {
+                    p1 = new byte?(byte.MaxValue),
+                    p2 = new sbyte?(sbyte.MaxValue),
+                    p3 = new short?(short.MaxValue),
+                    p4 = new ushort?(ushort.MaxValue),
+                    p5 = new uint?(uint.MaxValue),
+                    p6 = new ulong?(ulong.MaxValue)
+                }
+            };
+
+            var nulls = new[] {
+                new {
+                    p1 = new byte?(),
+                    p2 = new sbyte?(),
+                    p3 = new short?(),
+                    p4 = new ushort?(),
+                    p5 = new uint?(),
+                    p6 = new ulong?()
+                }
+            };
+
+            var valuesExpectation = new object[] {
+                (decimal)byte.MaxValue,
+                (decimal)sbyte.MaxValue,
+                (decimal)short.MaxValue,
+                (decimal)ushort.MaxValue,
+                (decimal)uint.MaxValue,
+                (decimal)ulong.MaxValue,
+            };
+
+            var nullsExpectation = new object[] { 0m, 0m, 0m, 0m, 0m, 0m };
+
+            var loadOptions = new SampleLoadOptions {
+                RemoteGrouping = true,
+                TotalSummary = Enumerable.Range(1, 6)
+                    .Select(i => new SummaryInfo { Selector = "p" + i, SummaryType = "sum" })
+                    .ToArray()
+            };
+
+            Assert.Equal(valuesExpectation, DataSourceLoader.Load(values, loadOptions).summary);
+            Assert.Equal(valuesExpectation, DataSourceLoader.Load(nullableValues, loadOptions).summary);
+            Assert.Equal(nullsExpectation, DataSourceLoader.Load(nulls, loadOptions).summary);
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Aggregation/DynamicSum.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/DynamicSum.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data.Aggregation {
+
+    static class DynamicSum {
+
+        public static object Calculate<T>(IEnumerable<T> source, Func<T, object> selector) {
+            var summator = new SumAggregator<object>(new IdentityAccessor());
+            foreach(var i in source.Select(selector))
+                summator.Step(i, null);
+            return summator.Finish();
+        }
+
+        class IdentityAccessor : IAccessor<object> {
+            public object Read(object container, string selector) {
+                return container;
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
(...or rewrite `RemoteGroupExpressionCompiler` slightly less than completely)

Resolves #184