### PR TITLE
"loadMethod" option (closes #161) + fix #190

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The client-side API consists of a single method, `DevExpress.data.AspNet.createS
 - `updateUrl` - the URL used to update data;       
 - `insertUrl` - the URL used to insert data;        
 - `deleteUrl` - the URL used to delete data;     
+- `loadMethod` - the HTTP method for load requests; "GET" by default;
 - `updateMethod` - the HTTP method for update requests; "PUT" by default;
 - `insertMethod` - the HTTP method for insert requests; "POST" by default;
 - `deleteMethod` - the HTTP method for delete requests; "DELETE" by default;

--- a/js-test/test.js
+++ b/js-test/test.js
@@ -444,7 +444,7 @@
                 insertUrl: "/insert",
                 onBeforeSend: function(op, ajax) {
                     assert.equal(op, "insert");
-                    assert.equal(ajax.type, "POST");
+                    assert.equal(ajax.method, "POST");
                     assert.deepEqual(ajax.data, {
                         values: '{"a":1}'
                     });
@@ -462,7 +462,7 @@
                 updateUrl: "/update",
                 onBeforeSend: function(op, ajax) {
                     assert.equal(op, "update");
-                    assert.equal(ajax.type, "PUT");
+                    assert.equal(ajax.method, "PUT");
                     assert.deepEqual(ajax.data, {
                         key: 123,
                         values: '{"a":1}'
@@ -481,7 +481,7 @@
                 deleteUrl: "/delete",
                 onBeforeSend: function(op, ajax) {
                     assert.equal(op, "delete");
-                    assert.equal(ajax.type, "DELETE");
+                    assert.equal(ajax.method, "DELETE");
                     assert.deepEqual(ajax.data, {
                         key: 123,
                     });
@@ -538,5 +538,37 @@
             store.insert(123, {}),
             store.remove(123)
         ]).then(done);
+    });
+
+    QUnit.test("custom HTTP methods", function(assert) {
+        var done = assert.async();
+        var actualMethods = [];
+
+        function notifyRequest() {
+            if(actualMethods.length > 3) {
+                assert.ok(actualMethods.indexOf("CUSTOM_LOAD") > -1);
+                assert.ok(actualMethods.indexOf("CUSTOM_INSERT") > -1);
+                assert.ok(actualMethods.indexOf("CUSTOM_UPDATE") > -1);
+                assert.ok(actualMethods.indexOf("CUSTOM_DELETE") > -1);
+                done();
+            }
+        }
+
+        XHRMock.use(function(req, res) {
+            actualMethods.push(req.method());
+            notifyRequest();
+        });
+
+        var options = { key: "any" };
+        [ "load", "insert", "update", "delete" ].forEach(function(op) {
+            options[op + "Url"] = "/";
+            options[op + "Method"] = "custom_" + op;
+        });
+
+        var store = createStore(options);
+        store.load();
+        store.insert({});
+        store.update(123, {});
+        store.remove(123);
     });
 });

--- a/js-test/test.js
+++ b/js-test/test.js
@@ -587,5 +587,5 @@
         store.insert({});
         store.update(123, {});
         store.remove(123);
-    });    
+    });
 });

--- a/js-test/test.js
+++ b/js-test/test.js
@@ -540,7 +540,6 @@
         ]).then(done);
     });
 
-
     QUnit.test("DevExtreme#2770", function(assert) {
         assert.expect(0);
         if(document.documentMode < 10)

--- a/js-test/test.js
+++ b/js-test/test.js
@@ -555,7 +555,7 @@
             done();
         });
     });
-    
+
     QUnit.test("custom HTTP methods", function(assert) {
         var done = assert.async();
         var actualMethods = [];

--- a/js-test/test.js
+++ b/js-test/test.js
@@ -561,11 +561,14 @@
         var actualMethods = [];
 
         function notifyRequest() {
-            if(actualMethods.length > 3) {
-                assert.ok(actualMethods.indexOf("CUSTOM_LOAD") > -1);
-                assert.ok(actualMethods.indexOf("CUSTOM_INSERT") > -1);
-                assert.ok(actualMethods.indexOf("CUSTOM_UPDATE") > -1);
-                assert.ok(actualMethods.indexOf("CUSTOM_DELETE") > -1);
+            if(actualMethods.length > 5) {
+                actualMethods.sort();
+                assert.deepEqual(actualMethods, [
+                    "CUSTOM_DELETE",
+                    "CUSTOM_INSERT",
+                    "CUSTOM_LOAD", "CUSTOM_LOAD", "CUSTOM_LOAD",
+                    "CUSTOM_UPDATE"
+                ]);
                 done();
             }
         }
@@ -583,6 +586,8 @@
 
         var store = createStore(options);
         store.load();
+        store.totalCount();
+        store.byKey(123);
         store.insert({});
         store.update(123, {});
         store.remove(123);

--- a/js/dx.aspnet.data.js
+++ b/js/dx.aspnet.data.js
@@ -35,6 +35,7 @@
     function createStoreConfig(options) {
         var keyExpr = options.key,
             loadUrl = options.loadUrl,
+            loadMethod = options.loadMethod || "GET",
             loadParams = options.loadParams,
             updateUrl = options.updateUrl,
             insertUrl = options.insertUrl,
@@ -142,6 +143,7 @@
                     false,
                     {
                         url: loadUrl,
+                        method: loadMethod,
                         data: loadOptionsToActionParams(loadOptions)
                     },
                     function(d, res) {
@@ -158,6 +160,7 @@
                     false,
                     {
                         url: loadUrl,
+                        method: loadMethod,
                         data: loadOptionsToActionParams(loadOptions, true)
                     },
                     function(d, res) {
@@ -174,6 +177,7 @@
                     true,
                     {
                         url: loadUrl,
+                        method: loadMethod,
                         data: loadOptionsToActionParams({ filter: filterByKey(key) })
                     },
                     function(d, res) {
@@ -187,7 +191,7 @@
             update: updateUrl && function(key, values) {
                 return send("update", true, {
                     url: updateUrl,
-                    type: options.updateMethod || "PUT",
+                    method: options.updateMethod || "PUT",
                     data: {
                         key: serializeKey(key),
                         values: JSON.stringify(values)
@@ -198,7 +202,7 @@
             insert: insertUrl && function(values) {
                 return send("insert", true, {
                     url: insertUrl,
-                    type: options.insertMethod || "POST",
+                    method: options.insertMethod || "POST",
                     data: { values: JSON.stringify(values) }
                 });
             },
@@ -206,7 +210,7 @@
             remove: deleteUrl && function(key) {
                 return send("delete", true, {
                     url: deleteUrl,
-                    type: options.deleteMethod || "DELETE",
+                    method: options.deleteMethod || "DELETE",
                     data: { key: serializeKey(key) }
                 });
             }


### PR DESCRIPTION
@San4es 

We'll need to add `LoadMethod(string httpMethod)` to `DataLibraryApiBuilder<T>`.

For .NET Core and MVC controllers, `DataSourceLoadOptions` binding works just fine:

```c#
[HttpPost]
public ActionResult Orders(DataSourceLoadOptions loadOptions) {
    var loadResult = DataSourceLoader.Load(_nwind.Orders, loadOptions);
    return Content(JsonConvert.SerializeObject(loadResult), "application/json");
}
```

```c#
[HttpPost("orders")]
public object Orders(DataSourceLoadOptions loadOptions) {
    return DataSourceLoader.Load(_nwind.Orders, loadOptions);
}
```

For WebApi, the `[FromBody]` attribute has to be added:

```c#
[HttpPost]
public HttpResponseMessage Orders([FromBody]DataSourceLoadOptions loadOptions) {
    return Request.CreateResponse(DataSourceLoader.Load(_nwind.Orders, loadOptions));
}
```