### PR TITLE
Prevent the appearance of "undefined" in query-string in jQuery-free mode

### DIFF
--- a/js-test/test.js
+++ b/js-test/test.js
@@ -272,6 +272,52 @@
             QUnit.test("as array", testCase([ "abc" ], [ "abc" ]));
         });
 
+        QUnit.test("undefined values", function(assert) {
+            var done = assert.async();
+
+            var loadOptionNames = [
+                "skip", "take",
+                "requireTotalCount", "requireGroupCount",
+                "sort", "group", "filter",
+                "totalSummary", "groupSummary"
+            ];
+
+            XHRMock.use(function(req) {
+                var query = req.url().query;
+                loadOptionNames.forEach(function(i) {
+                    assert.ok(!(i in query));
+                });
+                done();
+            });
+
+            var loadOptions = { };
+            loadOptionNames.forEach(function(i) {
+                loadOptions[i] = undefined;
+            });
+
+            createStore({ loadUrl: "/" }).load(loadOptions);
+        });
+
+        QUnit.test("zero and false", function(assert) {
+            var done = assert.async();
+
+            XHRMock.use(function(req) {
+                var query = req.url().query;
+                assert.equal(query.skip, "0");
+                assert.equal(query.take, "0");
+                assert.equal(query.requireTotalCount, "false");
+                assert.equal(query.requireGroupCount, "false");
+                done();
+            });
+
+            createStore({ loadUrl: "/" }).load({
+                skip: 0,
+                take: 0,
+                requireTotalCount: false,
+                requireGroupCount: false
+            });
+        });
+
     });
 
     QUnit.module("loading", function() {

--- a/js/dx.aspnet.data.js
+++ b/js/dx.aspnet.data.js
@@ -1,7 +1,7 @@
 // https://github.com/DevExpress/DevExtreme.AspNet.Data
 // Copyright (c) Developer Express Inc.
 
-// jshint strict: true, undef: true, unused: true, eqeqeq: true
+// jshint strict: true, undef: true, unused: true, eqeqeq: true, eqnull:true
 /* global DevExpress, jQuery, define */
 
 (function(factory) {
@@ -95,7 +95,7 @@
             if(options) {
 
                 ["skip", "take", "requireTotalCount", "requireGroupCount"].forEach(function(i) {
-                    if(i in options)
+                    if(options[i] != null)
                         result[i] = options[i];
                 });
 


### PR DESCRIPTION
Related changeset: https://github.com/DevExpress/DevExtreme/pull/2928