### PR TITLE
Accumulator classes + TimeSpan aggregation

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/AggregateCalculatorTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/AggregateCalculatorTests.cs
@@ -210,6 +210,34 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(data.Average(), totals[1]);
         }
 
+        [Fact]
+        public void TimeSpanType() {
+            var data = new[] {
+                TimeSpan.FromMinutes(1),
+                TimeSpan.FromMinutes(3)
+            };
+
+            var calculator = new AggregateCalculator<TimeSpan>(data, new DefaultAccessor<TimeSpan>(),
+                new[] {
+                    new SummaryInfo { Selector = "this", SummaryType = "min" },
+                    new SummaryInfo { Selector = "this", SummaryType = "max" },
+                    new SummaryInfo { Selector = "this", SummaryType = "sum" },
+                    new SummaryInfo { Selector = "this", SummaryType = "avg" }
+                },
+                null
+            );
+
+            Assert.Equal(
+                new object[] {
+                    TimeSpan.FromMinutes(1),
+                    TimeSpan.FromMinutes(3),
+                    TimeSpan.FromMinutes(4),
+                    TimeSpan.FromMinutes(2)
+                },
+                calculator.Run()
+            );
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/AccumulatorFactory.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/AccumulatorFactory.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data.Aggregation.Accumulators {
+
+    static class AccumulatorFactory {
+
+        public static IAccumulator Create(Type type) {
+            if(type == typeof(Double) || type == typeof(Single))
+                return new DoubleAccumulator();
+
+            if(type == typeof(TimeSpan))
+                return new TimeSpanAccumulator();
+
+            return new DecimalAccumulator();
+        }
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/DecimalAccumulator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/DecimalAccumulator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data.Aggregation.Accumulators {
+
+    class DecimalAccumulator : IAccumulator {
+        decimal _value;
+
+        public void Add(object value) {
+            _value += Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+        }
+
+        public void Divide(int divider) {
+            _value /= divider;
+        }
+
+        public object GetValue() {
+            return _value;
+        }
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/DoubleAccumulator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/DoubleAccumulator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data.Aggregation.Accumulators {
+
+    class DoubleAccumulator : IAccumulator {
+        double _value;
+
+        public void Add(object value) {
+            _value += Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        }
+
+        public void Divide(int divider) {
+            _value /= divider;
+        }
+
+        public object GetValue() {
+            return _value;
+        }
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/IAccumulator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/IAccumulator.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data.Aggregation.Accumulators {
+
+    interface IAccumulator {
+        void Add(object value);
+        void Divide(int divider);
+        object GetValue();
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/TimeSpanAccumulator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/Accumulators/TimeSpanAccumulator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data.Aggregation.Accumulators {
+
+    class TimeSpanAccumulator : IAccumulator {
+        TimeSpan _value;
+
+        public void Add(object value) {
+            _value += (TimeSpan)Convert.ChangeType(value, typeof(TimeSpan), CultureInfo.CurrentCulture);
+        }
+
+        public void Divide(int divider) {
+            _value = TimeSpan.FromTicks(_value.Ticks / divider);
+        }
+
+        public object GetValue() {
+            return _value;
+        }
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/Aggregation/AvgAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/AvgAggregator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Aggregation.Accumulators;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,12 +26,9 @@ namespace DevExtreme.AspNet.Data.Aggregation {
             if(count == 0)
                 return null;
 
-            var sum = _summator.Finish();
-
-            if(sum is Double doubleSum)
-                return doubleSum / count;
-
-            return (decimal)sum / count;
+            var accumulator = _summator.GetAccumulator();
+            accumulator.Divide(count);
+            return accumulator.GetValue();
         }
     }
 


### PR DESCRIPTION
This PR replaces conditional code with polymorphism and enables correct SUM & AVG summaries over `TimeSpan` data in `RemoteGrouping=false` mode. The latter can be used as a workaround for issues like #86 when in-memory aggregation is ok. For #195 we currently need more information, however, if the problem is caused by summaries then it should be resolved by this PR.