### PR TITLE
Update Utils.cs

### DIFF
--- a/net/DevExtreme.AspNet.Data/Utils.cs
+++ b/net/DevExtreme.AspNet.Data/Utils.cs
@@ -66,7 +66,7 @@ namespace DevExtreme.AspNet.Data {
 
         public static IEnumerable<SortingInfo> AddRequiredSort(IEnumerable<SortingInfo> sort, IEnumerable<string> requiredSelectors) {
             sort = sort ?? new SortingInfo[0];
-            requiredSelectors = requiredSelectors.Except(sort.Select(i => i.Selector));
+            requiredSelectors = requiredSelectors.Except(sort.Select(i => i.Selector), StringComparer.OrdinalIgnoreCase);
 
             var desc = sort.LastOrDefault()?.Desc;
 


### PR DESCRIPTION
Fix for an issue when sorting added on same field that is selected as default sort field when no primary key exists and field name case doesn't match. It wasn't recognizing duplicate sort selectors .
Proposed fix is to ignore case when identifying which sorting selectors are already present.