### PR TITLE
PreSelect load option

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -362,6 +362,39 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Null(x);
         }
 
+        [Fact]
+        public void Load_PreSelect() {
+            var data = new[] {
+                new { a = 1, b = 2, c = 3 }
+            };
+
+            IDictionary Load(string[] preSelect, string[] select) {
+                var loadResult = DataSourceLoader.Load(data, new SampleLoadOptions {
+                    PreSelect = preSelect,
+                    Select = select
+                });
+
+                return loadResult.data.Cast<IDictionary>().First();
+            }
+
+            var item = Load(
+                preSelect: new[] { "a", "b" },
+                select: null
+            );
+
+            Assert.Equal(2, item.Keys.Count);
+            Assert.True(item.Contains("a"));
+            Assert.True(item.Contains("b"));
+
+            item = Load(
+                preSelect: new[] { "a", "b" },
+                select: new[] { "b", "c" }
+            );
+
+            Assert.Equal(1, item.Keys.Count);
+            Assert.True(item.Contains("b"));
+        }
+
         [Theory]
         [InlineData(false, true)]
         [InlineData(false, false)]

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -42,8 +42,8 @@ namespace DevExtreme.AspNet.Data {
                 if(!remoteGrouping) {
                     if(_loadOptions.HasAnySort)
                         expr = new SortExpressionCompiler<T>(_guardNulls).Compile(expr, _loadOptions.GetFullSort());
-                    if(_loadOptions.HasSelect) {
-                        expr = new SelectExpressionCompiler<T>(_guardNulls).Compile(expr, _loadOptions.Select);
+                    if(_loadOptions.HasAnySelect) {
+                        expr = new SelectExpressionCompiler<T>(_guardNulls).Compile(expr, _loadOptions.GetFullSelect());
                         genericTypeArguments = expr.Type.GetGenericArguments();
                     }
                 } else {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -66,6 +67,9 @@ namespace DevExtreme.AspNet.Data {
         /// </summary>
         public string[] Select;
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string[] PreSelect;
+
         /// <summary>
         /// A flag that indicates whether grouping must be performed on the server side.
         /// </summary>
@@ -118,6 +122,14 @@ namespace DevExtreme.AspNet.Data {
             get { return HasGroups || HasSort || HasPrimaryKey || HasDefaultSort; }
         }
 
+        internal bool HasAnySelect {
+            get { return HasPreSelect || HasSelect; }
+        }
+
+        internal bool HasPreSelect {
+            get { return PreSelect != null && PreSelect.Length > 0; }
+        }
+
         internal bool HasSelect {
             get { return Select != null && Select.Length > 0; }
         }
@@ -155,6 +167,19 @@ namespace DevExtreme.AspNet.Data {
                 requiredSort = requiredSort.Concat(PrimaryKey);
 
             return Utils.AddRequiredSort(result, requiredSort);
+        }
+
+        internal IEnumerable<string> GetFullSelect() {
+            if(HasPreSelect && HasSelect)
+                return Enumerable.Intersect(PreSelect, Select);
+
+            if(HasPreSelect)
+                return PreSelect;
+
+            if(HasSelect)
+                return Select;
+
+            return Enumerable.Empty<string>();
         }
     }
 

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -64,7 +64,7 @@ namespace DevExtreme.AspNet.Data {
                 var deferPaging = Options.HasGroups || !CanUseRemoteGrouping && !SummaryIsTotalCountOnly && Options.HasSummary;
                 var loadExpr = Builder.BuildLoadExpr(Source.Expression, !deferPaging);
 
-                if(Options.HasSelect) {
+                if(Options.HasAnySelect) {
                     ContinueWithGrouping(
                         ExecExpr<AnonType>(Source, loadExpr).Select(ProjectionToDict),
                         Accessors.Dict,
@@ -194,10 +194,12 @@ namespace DevExtreme.AspNet.Data {
         }
 
         Dictionary<string, object> ProjectionToDict(AnonType projection) {
-            var names = Options.Select;
             var dict = new Dictionary<string, object>();
-            for(var i = 0; i < names.Length; i++)
-                ShrinkSelectResult(dict, names[i].Split('.'), projection[i]);
+            var index = 0;
+            foreach(var name in Options.GetFullSelect()) {
+                ShrinkSelectResult(dict, name.Split('.'), projection[index]);
+                index++;
+            }
             return dict;
         }
 

--- a/net/DevExtreme.AspNet.Data/SelectExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/SelectExpressionCompiler.cs
@@ -14,7 +14,7 @@ namespace DevExtreme.AspNet.Data {
             : base(guardNulls) {
         }
 
-        public Expression Compile(Expression target, string[] clientExprList) {
+        public Expression Compile(Expression target, IEnumerable<string> clientExprList) {
             var itemExpr = CreateItemParam(typeof(T));
 
             var accessors = clientExprList


### PR DESCRIPTION
A declarative alternative to the approach described by me in https://stackoverflow.com/a/49006427

Together with #206 (`RemoteSelect`) it will make possible to select unbound/unmapped props from EF entities:

```c#
class Category {
    public string Name { get; set; }    
    public Byte[] Picture { get; set; }

    [NotMapped]
    public string PictureUrl {
        /* ... */
    }
}

new DataSourceLoadOptions {
    PreSelect = new[] { "Name", "PictureUrl" },
    Select = /* can be optionally set from the client-side */,    
    RemoteSelect = false
}
```