### PR TITLE
Move accessors to Helpers namespace

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/AggregateCalculatorTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/AggregateCalculatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.Aggregation;
+using DevExtreme.AspNet.Data.Helpers;
 using DevExtreme.AspNet.Data.ResponseModel;
 using System;
 using System.Collections.Generic;

--- a/net/DevExtreme.AspNet.Data.Tests/AnonTypeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/AnonTypeTests.cs
@@ -1,4 +1,5 @@
-﻿using DevExtreme.AspNet.Data.Types;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using DevExtreme.AspNet.Data.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/net/DevExtreme.AspNet.Data.Tests/CustomAggregatorsTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/CustomAggregatorsTests.cs
@@ -1,4 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.Aggregation;
+using DevExtreme.AspNet.Data.Helpers;
 using System;
 using Xunit;
 

--- a/net/DevExtreme.AspNet.Data.Tests/GroupHelperTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/GroupHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using DevExtreme.AspNet.Data.ResponseModel;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using DevExtreme.AspNet.Data.ResponseModel;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/net/DevExtreme.AspNet.Data/Aggregation/AggregateCalculator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/AggregateCalculator.cs
@@ -1,4 +1,5 @@
-﻿using DevExtreme.AspNet.Data.RemoteGrouping;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using DevExtreme.AspNet.Data.RemoteGrouping;
 using DevExtreme.AspNet.Data.ResponseModel;
 using System;
 using System.Collections;

--- a/net/DevExtreme.AspNet.Data/Aggregation/Aggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/Aggregator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/net/DevExtreme.AspNet.Data/Aggregation/AvgAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/AvgAggregator.cs
@@ -1,4 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.Aggregation.Accumulators;
+using DevExtreme.AspNet.Data.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/net/DevExtreme.AspNet.Data/Aggregation/CountAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/CountAggregator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/net/DevExtreme.AspNet.Data/Aggregation/CustomAggregators.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/CustomAggregators.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using System;
 using System.Collections.Generic;
 
 namespace DevExtreme.AspNet.Data.Aggregation {

--- a/net/DevExtreme.AspNet.Data/Aggregation/DynamicSum.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/DynamicSum.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/net/DevExtreme.AspNet.Data/Aggregation/MaxAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/MaxAggregator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/net/DevExtreme.AspNet.Data/Aggregation/MinAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/MinAggregator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/net/DevExtreme.AspNet.Data/Aggregation/SumAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/SumAggregator.cs
@@ -1,4 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.Aggregation.Accumulators;
+using DevExtreme.AspNet.Data.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/net/DevExtreme.AspNet.Data/GroupHelper.cs
+++ b/net/DevExtreme.AspNet.Data/GroupHelper.cs
@@ -1,4 +1,5 @@
-﻿using DevExtreme.AspNet.Data.ResponseModel;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using DevExtreme.AspNet.Data.ResponseModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/net/DevExtreme.AspNet.Data/Helpers/Accessors.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/Accessors.cs
@@ -2,9 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace DevExtreme.AspNet.Data {
+namespace DevExtreme.AspNet.Data.Helpers {
 
     static class Accessors {
         public static readonly IAccessor<IDictionary<string, object>> Dict = new DictImpl();

--- a/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
@@ -2,9 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 
-namespace DevExtreme.AspNet.Data {
+namespace DevExtreme.AspNet.Data.Helpers {
 
     class DefaultAccessor<T> : ExpressionCompiler, IAccessor<T> {
         IDictionary<string, Func<T, object>> _accessors;

--- a/net/DevExtreme.AspNet.Data/Helpers/IAccessor.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/IAccessor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
-namespace DevExtreme.AspNet.Data {
+namespace DevExtreme.AspNet.Data.Helpers {
 
     public interface IAccessor<T> {
         object Read(T container, string selector);

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs
@@ -1,4 +1,5 @@
-﻿using DevExtreme.AspNet.Data.Types;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using DevExtreme.AspNet.Data.Types;
 using System;
 using System.Linq;
 

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteCountAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteCountAggregator.cs
@@ -1,4 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.Aggregation;
+using DevExtreme.AspNet.Data.Helpers;
 using DevExtreme.AspNet.Data.Types;
 using System;
 using System.Collections.Generic;

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupTransformer.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.Aggregation;
+using DevExtreme.AspNet.Data.Helpers;
 using DevExtreme.AspNet.Data.ResponseModel;
 using DevExtreme.AspNet.Data.Types;
 using System;


### PR DESCRIPTION
Reason: to not pollute the main namespace with the rare used functionality.
`IAccessor<T>` has been published in #205

FYI @San4es 