### PR TITLE
 Make "devextreme" a peer dependency

### DIFF
--- a/build/make-nojquery.js
+++ b/build/make-nojquery.js
@@ -36,10 +36,10 @@ if(!fs.existsSync(outputPath))
 
 const originalPackageJSON = require("../package.json");
 const nojqueryPackageJSON = { };
-[ "name", "title", "version", "description", "homepage", "license", "author", "repository", "dependencies" ]
+[ "name", "title", "version", "description", "homepage", "license", "author", "repository", "dependencies", "peerDependencies" ]
     .forEach(i => nojqueryPackageJSON[i] = originalPackageJSON[i]);
 nojqueryPackageJSON.name += "-nojquery";
-nojqueryPackageJSON.dependencies.devextreme = ">=17.2.6-pre-18044";
+nojqueryPackageJSON.peerDependencies.devextreme = ">=17.2.6-pre-18044";
 fs.writeFileSync(path.join(outputPath, "package.json"), JSON.stringify(nojqueryPackageJSON, null, "  "));
 
 fs.writeFileSync(

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "js/dx.aspnet.data.js",
   "types": "js/dx.aspnet.data.d.ts",
-  "dependencies": {
+  "peerDependencies": {
     "devextreme": ">=16.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to address https://github.com/DevExpress/DevExtreme.AspNet.Data/issues/214#issuecomment-376144778.

Consider project.json:

```
{
  "dependencies": {
    "devextreme": "^17.2.7",
    "devextreme-aspnet-data-nojquery": "^1.4.0"
  }
}
```

Using NPM v5, run `npm i devextreme-aspnet-data-nojquery `, then `npm i`

DevExtreme will be installed into 2 locations:
- `node_modules\devextreme`
- `node_modules\devextreme-aspnet-data-nojquery\node_modules\devextreme`

which causes headaches like #214.

The peer dependency approach has been used in [devextreme-angular](https://github.com/DevExpress/devextreme-angular/blob/20ef8bf6d19fa877f62b5b51f3fc8bfd7caa1d7d/package.json#L19-L20). Works fine.

