### PR TITLE
Sample - Add quotes to pre-build command

### DIFF
--- a/net/Sample/Sample.csproj
+++ b/net/Sample/Sample.csproj
@@ -32,7 +32,7 @@
 
   <!-- https://github.com/dotnet/sdk/issues/1055#issuecomment-292792445 -->
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="xcopy /y &quot;$(ProjectDir)..\..\js\*.js&quot; &quot;$(ProjectDir)wwwroot\lib\&quot;" />
+    <Exec Command="xcopy /y &quot;$(ProjectDir)\..\..\js\*.js&quot; &quot;$(ProjectDir)\wwwroot\lib\&quot;" />
   </Target>
 
 </Project>

--- a/net/Sample/Sample.csproj
+++ b/net/Sample/Sample.csproj
@@ -32,7 +32,7 @@
 
   <!-- https://github.com/dotnet/sdk/issues/1055#issuecomment-292792445 -->
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="xcopy /y $(ProjectDir)\..\..\js\*.js $(ProjectDir)\wwwroot\lib\" />
+    <Exec Command="xcopy /y &quot;$(ProjectDir)..\..\js\*.js&quot; &quot;$(ProjectDir)wwwroot\lib\&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
To avoid issues with "xcopy" (e.g. white spaces in a path to the repo).