### PR TITLE
Fix #239

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.EF6/Bug239.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/Bug239.cs
@@ -1,0 +1,48 @@
+﻿using DevExtreme.AspNet.Data.ResponseModel;
+using System;
+using System.Data.Entity;
+using System.Linq;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests.EF6 {
+
+    class Bug239_DataItem {
+        public int ID { get; set; }
+        public DateTime? OrderDate { get; set; }
+        public Decimal? Freight { get; set; }
+    }
+
+    partial class TestDbContext {
+        public DbSet<Bug239_DataItem> Bug239_Data { get; set; }
+    }
+
+    public class Bug239 {
+
+        [Fact]
+        public void Scenario() {
+            TestDbContext.Exec(context => {
+                var dbSet = context.Bug239_Data;
+
+                dbSet.Add(new Bug239_DataItem());
+                dbSet.Add(new Bug239_DataItem { OrderDate = new DateTime(2009, 9, 9), Freight = 199 });
+                context.SaveChanges();
+
+                var loadResult = DataSourceLoader.Load(dbSet, new SampleLoadOptions {
+                    Group = new[] {
+                        new GroupingInfo { Selector = "OrderDate", IsExpanded = false, GroupInterval = "quarter" },
+                        new GroupingInfo { Selector = "Freight", IsExpanded = false, GroupInterval = "50" }
+                    }
+                });
+
+                var groups = loadResult.data.Cast<Group>().ToArray();
+
+                Assert.Null(groups[0].key);
+                Assert.Null((groups[0].items[0] as Group).key);
+
+                Assert.Equal(3, groups[1].key);
+                Assert.Equal(150m, (groups[1].items[0] as Group).key);
+            });
+        }
+
+    }
+}

--- a/net/DevExtreme.AspNet.Data.Tests.EF6/DevExtreme.AspNet.Data.Tests.EF6.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/DevExtreme.AspNet.Data.Tests.EF6.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Bug179.cs" />
     <Compile Include="Bug184.cs" />
     <Compile Include="Bug235.cs" />
+    <Compile Include="Bug239.cs" />
     <Compile Include="Bug240.cs" />
     <Compile Include="SelectNotMapped.cs" />
     <Compile Include="TestDbContext.cs" />

--- a/net/DevExtreme.AspNet.Data.Tests/ExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/ExpressionCompilerTests.cs
@@ -35,7 +35,10 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         string CompileAccessor(bool guardNulls, string selector, bool forceToString = false) {
             return new SampleCompiler(guardNulls)
-                .CompileAccessorExpression(Expression.Parameter(typeof(TargetClass), "t"), selector, forceToString)
+                .CompileAccessorExpression(Expression.Parameter(typeof(TargetClass), "t"), selector, progression => {
+                    if(forceToString)
+                        ExpressionCompiler.ForceToString(progression);
+                })
                 .ToString();
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests/ExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/ExpressionCompilerTests.cs
@@ -33,12 +33,9 @@ namespace DevExtreme.AspNet.Data.Tests {
             }
         }
 
-        string CompileAccessor(bool guardNulls, string selector, bool forceToString = false) {
+        string CompileAccessor(bool guardNulls, string selector, Action<List<Expression>> customizeProgression = null) {
             return new SampleCompiler(guardNulls)
-                .CompileAccessorExpression(Expression.Parameter(typeof(TargetClass), "t"), selector, progression => {
-                    if(forceToString)
-                        ExpressionCompiler.ForceToString(progression);
-                })
+                .CompileAccessorExpression(Expression.Parameter(typeof(TargetClass), "t"), selector, customizeProgression)
                 .ToString();
         }
 
@@ -93,23 +90,23 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void Accessor_ForceToString() {
-            Assert.Equal("t.String", CompileAccessor(false, "String", true));
-            Assert.Equal("t.Value.ToString()", CompileAccessor(false, "Value", true));
-            Assert.Equal("t.Ref.ToString()", CompileAccessor(false, "Ref", true));
+            Assert.Equal("t.String", CompileAccessor(false, "String", ExpressionCompiler.ForceToString));
+            Assert.Equal("t.Value.ToString()", CompileAccessor(false, "Value", ExpressionCompiler.ForceToString));
+            Assert.Equal("t.Ref.ToString()", CompileAccessor(false, "Ref", ExpressionCompiler.ForceToString));
 
             Assert.Equal(
                 "IIF((t == null), null, t.String)",
-                CompileAccessor(true, "String", true)
+                CompileAccessor(true, "String", ExpressionCompiler.ForceToString)
             );
 
             Assert.Equal(
                 "IIF((t == null), null, t.Value.ToString())",
-                CompileAccessor(true, "Value", true)
+                CompileAccessor(true, "Value", ExpressionCompiler.ForceToString)
             );
 
             Assert.Equal(
                 "IIF((((t == null) OrElse (t.Ref == null)) OrElse (t.Ref.Ref == null)), null, t.Ref.Ref.ToString())",
-                CompileAccessor(true, "Ref.Ref", true)
+                CompileAccessor(true, "Ref.Ref", ExpressionCompiler.ForceToString)
             );
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -124,7 +124,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
 
             var expr = compiler.Compile(CreateTargetParam<double?>()).ToString();
-#warning TODO assert
+            Assert.Contains("I0 = (obj - (obj % 123)", expr);
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             var expr = compiler.Compile(CreateTargetParam<Nullable<DateTime>>()).ToString();
 
-            Assert.Contains("I0 = IIF((obj == null), null, " +  Compat.ExpectedConvert("obj.Value.Year", "Nullable`1") + ")", expr);
+            Assert.Contains("I0 = " +  Compat.ExpectedConvert("obj.Value.Year", "Nullable`1"), expr);
         }
 
         [Fact]

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -115,6 +115,19 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
+        public void GroupInterval_NullableNumeric() {
+            var compiler = new RemoteGroupExpressionCompiler<double?>(
+                new[] {
+                    new GroupingInfo { Selector = "this", GroupInterval = "123" }
+                },
+                null, null
+            );
+
+            var expr = compiler.Compile(CreateTargetParam<double?>()).ToString();
+#warning TODO assert
+        }
+
+        [Fact]
         public void GroupInterval_Date() {
             var compiler = new RemoteGroupExpressionCompiler<DateTime>(
                 new[] {

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -127,44 +127,72 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void GroupInterval_Date() {
-            var compiler = new RemoteGroupExpressionCompiler<DateTime>(
-                new[] {
-                    new GroupingInfo { Selector = "this", GroupInterval = "year" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "quarter" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "month" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "day" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "dayOfWeek" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "hour" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "minute" },
-                    new GroupingInfo { Selector = "this", GroupInterval = "second" }
-                },
-                null, null
-            );
 
-            var expr = compiler.Compile(CreateTargetParam<DateTime>()).ToString();
+            string Compile<T>(string selector, bool guardNulls) {
+                var compiler = new RemoteGroupExpressionCompiler<T>(
+                    guardNulls,
+                    new[] {
+                        new GroupingInfo { Selector = selector, GroupInterval = "year" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "quarter" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "month" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "day" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "dayOfWeek" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "hour" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "minute" },
+                        new GroupingInfo { Selector = selector, GroupInterval = "second" }
+                    },
+                    null, null
+                );
 
-            Assert.Contains("I0 = obj.Year", expr);
-            Assert.Contains("I1 = ((obj.Month + 2) / 3)", expr);
-            Assert.Contains("I2 = obj.Month", expr);
-            Assert.Contains("I3 = obj.Day", expr);
-            Assert.Contains("I4 = " + Compat.ExpectedConvert("obj.DayOfWeek", "Int32"), expr);
-            Assert.Contains("I5 = obj.Hour", expr);
-            Assert.Contains("I6 = obj.Minute", expr);
-            Assert.Contains("I7 = obj.Second", expr);
-        }
+                return compiler.Compile(CreateTargetParam<T>()).ToString();
+            }
 
-        [Fact]
-        public void GroupInterval_NullableDate() {
-            var compiler = new RemoteGroupExpressionCompiler<Nullable<DateTime>>(
-                new[] {
-                    new GroupingInfo { Selector = "this", GroupInterval = "year" }
-                },
-                null, null
-            );
+            {
+                var expr = Compile<DateTime>("this", false);
 
-            var expr = compiler.Compile(CreateTargetParam<Nullable<DateTime>>()).ToString();
+                Assert.Contains("I0 = obj.Year", expr);
+                Assert.Contains("I1 = ((obj.Month + 2) / 3)", expr);
+                Assert.Contains("I2 = obj.Month", expr);
+                Assert.Contains("I3 = obj.Day", expr);
+                Assert.Contains("I4 = " + Compat.ExpectedConvert("obj.DayOfWeek", "Int32"), expr);
+                Assert.Contains("I5 = obj.Hour", expr);
+                Assert.Contains("I6 = obj.Minute", expr);
+                Assert.Contains("I7 = obj.Second", expr);
+            }
 
-            Assert.Contains("I0 = " +  Compat.ExpectedConvert("obj.Value.Year", "Nullable`1"), expr);
+            {
+                var expr = Compile<DateTime?>("this", false);
+
+                string Wrap(string coreSelector) {
+                    return Compat.ExpectedConvert(coreSelector, "Nullable`1");
+                }
+
+                Assert.Contains("I0 = " + Wrap("obj.Value.Year"), expr);
+                Assert.Contains("I1 = " + Wrap("((obj.Value.Month + 2) / 3)"), expr);
+                Assert.Contains("I2 = " + Wrap("obj.Value.Month"), expr);
+                Assert.Contains("I3 = " + Wrap("obj.Value.Day"), expr);
+                Assert.Contains("I4 = " + Wrap("obj.Value.DayOfWeek"), expr);
+                Assert.Contains("I5 = " + Wrap("obj.Value.Hour"), expr);
+                Assert.Contains("I6 = " + Wrap("obj.Value.Minute"), expr);
+                Assert.Contains("I7 = " + Wrap("obj.Value.Second"), expr);
+            }
+
+            {
+                var expr = Compile<Tuple<DateTime?>>("Item1", true);
+
+                string Wrap(string coreSelector) {
+                    return $"IIF(((obj == null) OrElse (obj.Item1 == null)), null, {Compat.ExpectedConvert(coreSelector, "Nullable`1")})";
+                }
+
+                Assert.Contains("I0 = " + Wrap("obj.Item1.Value.Year"), expr);
+                Assert.Contains("I1 = " + Wrap("((obj.Item1.Value.Month + 2) / 3)"), expr);
+                Assert.Contains("I2 = " + Wrap("obj.Item1.Value.Month"), expr);
+                Assert.Contains("I3 = " + Wrap("obj.Item1.Value.Day"), expr);
+                Assert.Contains("I4 = " + Wrap("obj.Item1.Value.DayOfWeek"), expr);
+                Assert.Contains("I5 = " + Wrap("obj.Item1.Value.Hour"), expr);
+                Assert.Contains("I6 = " + Wrap("obj.Item1.Value.Minute"), expr);
+                Assert.Contains("I7 = " + Wrap("obj.Item1.Value.Second"), expr);
+            }
         }
 
         [Fact]

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -103,28 +103,26 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void GroupInterval_Numeric() {
-            var compiler = new RemoteGroupExpressionCompiler<double>(
-                new[] {
-                    new GroupingInfo { Selector = "this", GroupInterval = "123" }
-                },
-                null, null
+
+            string Compile<T>(string selector, bool guardNulls) {
+                var compiler = new RemoteGroupExpressionCompiler<T>(
+                    guardNulls,
+                    new[] {
+                        new GroupingInfo { Selector = selector, GroupInterval = "123" }
+                    },
+                    null, null
+                );
+
+                return compiler.Compile(CreateTargetParam<T>()).ToString();
+            }
+
+            Assert.Contains("I0 = (obj - (obj % 123)", Compile<double>("this", false));
+            Assert.Contains("I0 = (obj - (obj % 123)", Compile<double?>("this", false));
+
+            Assert.Contains(
+                $"I0 = IIF(((obj == null) OrElse (obj.Item1 == null)), null, {Compat.ExpectedConvert("(obj.Item1.Length - (obj.Item1.Length % 123))", "Nullable`1")})",
+                Compile<Tuple<string>>("Item1.Length", true)
             );
-
-            var expr = compiler.Compile(CreateTargetParam<double>()).ToString();
-            Assert.Contains("I0 = (obj - (obj % 123)", expr);
-        }
-
-        [Fact]
-        public void GroupInterval_NullableNumeric() {
-            var compiler = new RemoteGroupExpressionCompiler<double?>(
-                new[] {
-                    new GroupingInfo { Selector = "this", GroupInterval = "123" }
-                },
-                null, null
-            );
-
-            var expr = compiler.Compile(CreateTargetParam<double?>()).ToString();
-            Assert.Contains("I0 = (obj - (obj % 123)", expr);
         }
 
         [Fact]

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -111,7 +111,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
 
             var expr = compiler.Compile(CreateTargetParam<double>()).ToString();
-            Assert.Contains("I0 = (obj - (obj % " + Compat.ExpectedConvert(123, "Double") + ")", expr);
+            Assert.Contains("I0 = (obj - (obj % 123)", expr);
         }
 
         [Fact]

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -18,7 +18,7 @@ namespace DevExtreme.AspNet.Data {
             get { return _guardNulls; }
         }
 
-        protected internal Expression CompileAccessorExpression(Expression target, string clientExpr, bool forceToString = false, bool liftToNullable = false) {
+        protected internal Expression CompileAccessorExpression(Expression target, string clientExpr, Action<List<Expression>> customizeProgression = null, bool liftToNullable = false) {
             if(clientExpr == "this")
                 return target;
 
@@ -43,8 +43,7 @@ namespace DevExtreme.AspNet.Data {
                 progression.Add(currentTarget);
             }
 
-            if(forceToString && currentTarget.Type != typeof(String))
-                progression.Add(Expression.Call(currentTarget, typeof(Object).GetMethod(nameof(Object.ToString))));
+            customizeProgression?.Invoke(progression);
 
             if(_guardNulls && progression.Count > 1 || liftToNullable && progression.Count > 2) {
                 var lastIndex = progression.Count - 1;
@@ -92,6 +91,12 @@ namespace DevExtreme.AspNet.Data {
 
         protected ParameterExpression CreateItemParam(Type type) {
             return Expression.Parameter(type, "obj");
+        }
+
+        internal static void ForceToString(List<Expression> progression) {
+            var last = progression.Last();
+            if(last.Type != typeof(String))
+                progression.Add(Expression.Call(last, typeof(Object).GetMethod(nameof(Object.ToString))));
         }
 
     }

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -19,9 +19,6 @@ namespace DevExtreme.AspNet.Data {
         }
 
         protected internal Expression CompileAccessorExpression(Expression target, string clientExpr, Action<List<Expression>> customizeProgression = null, bool liftToNullable = false) {
-            if(clientExpr == "this")
-                return target;
-
             var progression = new List<Expression> { target };
 
             var clientExprItems = clientExpr.Split('.');
@@ -29,6 +26,9 @@ namespace DevExtreme.AspNet.Data {
 
             for(var i = 0; i < clientExprItems.Length; i++) {
                 var clientExprItem = clientExprItems[i];
+
+                if(i == 0 && clientExprItem == "this")
+                    continue;
 
                 if(Utils.IsNullable(currentTarget.Type)) {
                     clientExprItem = "Value";

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -44,7 +44,10 @@ namespace DevExtreme.AspNet.Data {
             var clientValue = criteriaJson[hasExplicitOperation ? 2 : 1];
             var isStringOperation = clientOperation == CONTAINS || clientOperation == NOT_CONTAINS || clientOperation == STARTS_WITH || clientOperation == ENDS_WITH;
 
-            var accessorExpr = CompileAccessorExpression(dataItemExpr, clientAccessor, isStringOperation);
+            var accessorExpr = CompileAccessorExpression(dataItemExpr, clientAccessor, progression => {
+                if(isStringOperation)
+                    ForceToString(progression);
+            });
 
             if(isStringOperation) {
                 return CompileStringFunction(accessorExpr, clientOperation, Convert.ToString(clientValue));

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
@@ -236,7 +236,8 @@ namespace DevExtreme.AspNet.Data.RemoteGrouping {
                             Expression.Constant(3)
                         );
                     } else if(intervalString == "dayOfWeek") {
-                        progression[lastIndex] = Expression.Convert(last, typeof(int));
+                        var hasNullable = progression.Any(i => Utils.CanAssignNull(i.Type));
+                        progression[lastIndex] = Expression.Convert(last, hasNullable ? typeof(int?) : typeof(int));
                     }
                 },
                 true

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
@@ -210,17 +210,15 @@ namespace DevExtreme.AspNet.Data.RemoteGrouping {
 
         Expression CompileGroupIntervalCore(Expression selector, string intervalString) {
             if(Char.IsDigit(intervalString[0])) {
+                var intervalExpr = Expression.Constant(
+                    Utils.ConvertClientValue(intervalString, selector.Type),
+                    selector.Type
+                );
+
                 return Expression.MakeBinary(
                     ExpressionType.Subtract,
                     selector,
-                    Expression.MakeBinary(
-                        ExpressionType.Modulo,
-                        selector,
-                        Expression.Convert(
-                            Expression.Constant(Int32.Parse(intervalString)),
-                            selector.Type
-                        )
-                    )
+                    Expression.MakeBinary(ExpressionType.Modulo, selector, intervalExpr)
                 );
             }
 


### PR DESCRIPTION
Related issue: #239

Change summary:
- Add `customizeProgression` callback to `ExpressionCompiler.CompileAccessorExpression` which is used to customize the expression for `ToString()`, day of week, and date quarter.
- `CompileGroupInterval` rewritten. Less code. Simpler resulting expressions.
- Better test coverage of interval grouping