### PR TITLE
Fix #246

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.EF6/Bug240.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/Bug240.cs
@@ -31,8 +31,8 @@ namespace DevExtreme.AspNet.Data.Tests.EF6 {
 
                 var items = loadResult.data.Cast<dynamic>().ToArray();
 
-                Assert.Null(items[0]["Date"]["Year"]);
-                Assert.Null(items[0]["Text"]["Length"]);
+                Assert.Null(items[0].Date.Year);
+                Assert.Null(items[0].Text.Length);
             });
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests.EF6/SelectNotMapped.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/SelectNotMapped.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Linq;
@@ -46,11 +46,11 @@ namespace DevExtreme.AspNet.Data.Tests.EF6 {
 
                 loadOptions.RemoteSelect = false;
                 var loadResult = DataSourceLoader.Load(dbSet, loadOptions);
-                var item = loadResult.data.Cast<IDictionary>().First();
+                var item = loadResult.data.Cast<IDictionary<string, object>>().First();
 
                 Assert.Equal(3, item.Keys.Count);
-                Assert.True(item.Contains("ID"));
-                Assert.True(item.Contains("Name"));
+                Assert.True(item.ContainsKey("ID"));
+                Assert.True(item.ContainsKey("Name"));
                 Assert.Equal("blob:j123", item["BlobUrl"]);
             });
         }

--- a/net/DevExtreme.AspNet.Data.Tests/Bug240Tests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/Bug240Tests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -123,7 +123,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             };
 
             var loadResult = DataSourceLoader.Load(data, loadOptions);
-            var items = loadResult.data.Cast<IDictionary>();
+            var items = loadResult.data.Cast<IDictionary<string, object>>();
             Assert.Null(items.First()["Length"]);
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -1,6 +1,5 @@
 ﻿using DevExtreme.AspNet.Data.ResponseModel;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -236,7 +235,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 Select = new[] { "f2" }
             };
 
-            var item = DataSourceLoader.Load(data, loadOptions).data.Cast<IDictionary>().First();
+            var item = DataSourceLoader.Load(data, loadOptions).data.Cast<IDictionary<string, object>>().First();
 
             Assert.Equal(1, item.Keys.Count);
             Assert.Equal(2, item["f2"]);
@@ -256,11 +255,11 @@ namespace DevExtreme.AspNet.Data.Tests {
             };
 
             var groups = (IList<Group>)DataSourceLoader.Load(data, loadOptions).data;
-            var item = (IDictionary)groups[0].items[0];
+            var item = (IDictionary<string, object>)groups[0].items[0];
 
             Assert.Equal(2, item.Keys.Count);
-            Assert.True(item.Contains("g"));
-            Assert.True(item.Contains("f"));
+            Assert.True(item.ContainsKey("g"));
+            Assert.True(item.ContainsKey("f"));
         }
 
         [Fact]
@@ -308,11 +307,11 @@ namespace DevExtreme.AspNet.Data.Tests {
                 Select = new[] { "Name", "Address.City", "Address.Street.Line1", "Contacts.Email" }
             };
 
-            var item = DataSourceLoader.Load(data, loadOptions).data.Cast<IDictionary>().First();
+            var item = DataSourceLoader.Load(data, loadOptions).data.Cast<IDictionary<string, object>>().First();
 
-            var address = (IDictionary)item["Address"];
-            var addressStreet = (IDictionary)address["Street"];
-            var contacts = (IDictionary)item["Contacts"];
+            var address = (IDictionary<string, object>)item["Address"];
+            var addressStreet = (IDictionary<string, object>)address["Street"];
+            var contacts = (IDictionary<string, object>)item["Contacts"];
 
             Assert.Equal(3, item.Keys.Count);
             Assert.Equal(2, address.Keys.Count);
@@ -336,9 +335,9 @@ namespace DevExtreme.AspNet.Data.Tests {
                 }
             );
 
-            var item = result.data.Cast<IDictionary>().First();
+            var item = result.data.Cast<IDictionary<string, object>>().First();
             Assert.Equal(1, item.Keys.Count);
-            Assert.True(item.Contains("Item1"));
+            Assert.True(item.ContainsKey("Item1"));
         }
 
         [Fact]
@@ -368,13 +367,13 @@ namespace DevExtreme.AspNet.Data.Tests {
                 new { a = 1, b = 2, c = 3 }
             };
 
-            IDictionary Load(string[] preSelect, string[] select) {
+            IDictionary<string, object> Load(string[] preSelect, string[] select) {
                 var loadResult = DataSourceLoader.Load(data, new SampleLoadOptions {
                     PreSelect = preSelect,
                     Select = select
                 });
 
-                return loadResult.data.Cast<IDictionary>().First();
+                return loadResult.data.Cast<IDictionary<string, object>>().First();
             }
 
             var item = Load(
@@ -383,8 +382,8 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
 
             Assert.Equal(2, item.Keys.Count);
-            Assert.True(item.Contains("a"));
-            Assert.True(item.Contains("b"));
+            Assert.True(item.ContainsKey("a"));
+            Assert.True(item.ContainsKey("b"));
 
             item = Load(
                 preSelect: new[] { "a", "b" },
@@ -392,7 +391,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
 
             Assert.Equal(1, item.Keys.Count);
-            Assert.True(item.Contains("b"));
+            Assert.True(item.ContainsKey("b"));
         }
 
         [Fact]
@@ -402,7 +401,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 RemoteSelect = false
             });
 
-            var item = loadResult.data.Cast<IDictionary>().First();
+            var item = loadResult.data.Cast<IDictionary<string, object>>().First();
 
             Assert.Single(item.Keys);
             Assert.Equal(1, item["a"]);
@@ -451,6 +450,29 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             var loadResult = DataSourceLoader.Load(data, loadOptions);
             Assert.NotEmpty(loadResult.data);
+        }
+
+        [Fact]
+        public void Issue246() {
+            var data = new[] {
+                new {
+                    Department = new { Title = "abc" }
+                }
+            };
+
+            var loadOptions = new SampleLoadOptions {
+                Select = new[] { "Department.Title" },
+                Group = new[] {
+                    new GroupingInfo { Selector = "Department.Title.Length" }
+                }
+            };
+
+            var groups = (IList<Group>)DataSourceLoader.Load(data, loadOptions).data;
+            Assert.Equal(3, groups[0].key);
+
+            var item = (IDictionary<string, object>)groups[0].items[0];
+            var department = (IDictionary<string, object>)item["Department"];
+            Assert.Equal("abc", department["Title"]);
         }
     }
 

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -35,7 +36,9 @@ namespace DevExtreme.AspNet.Data {
                     i--;
                 }
 
-                if(DynamicBindingHelper.ShouldUseDynamicBinding(currentTarget.Type))
+                if(currentTarget.Type == typeof(ExpandoObject))
+                    currentTarget = ReadExpando(currentTarget, clientExprItem);
+                else if(DynamicBindingHelper.ShouldUseDynamicBinding(currentTarget.Type))
                     currentTarget = DynamicBindingHelper.CompileGetMember(currentTarget, clientExprItem);
                 else
                     currentTarget = Expression.PropertyOrField(currentTarget, clientExprItem);
@@ -99,6 +102,13 @@ namespace DevExtreme.AspNet.Data {
                 progression.Add(Expression.Call(last, typeof(Object).GetMethod(nameof(Object.ToString))));
         }
 
+        static Expression ReadExpando(Expression expando, string member) {
+            return Expression.Property(
+                Expression.Convert(expando, typeof(IDictionary<string, object>)),
+                "Item",
+                Expression.Constant(member)
+            );
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Helpers/Accessors.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/Accessors.cs
@@ -6,14 +6,7 @@ using System.Linq;
 namespace DevExtreme.AspNet.Data.Helpers {
 
     static class Accessors {
-        public static readonly IAccessor<IDictionary<string, object>> Dict = new DictImpl();
         public static readonly IAccessor<AnonType> AnonType = new AnonTypeImpl();
-
-        class DictImpl : IAccessor<IDictionary<string, object>> {
-            public object Read(IDictionary<string, object> container, string selector) {
-                return container[selector];
-            }
-        }
 
         class AnonTypeImpl : IAccessor<AnonType> {
             public object Read(AnonType container, string selector) {


### PR DESCRIPTION
Related issue: #246

Instead of adding more logic to `Accessors.DictImpl`, I remove it and use dynamic capabilites of `ExpressionCompiler.CompileAccessorExpression`

Possible pitfall: MVC Controllers that use `JsonResult` may break, as described in https://stackoverflow.com/q/5156664. Technically we can convert expandos to hashtables but I'm not sure it's a good tradeoff. I suggest to mention it and the corresponding workaround in next release notes.