### PR TITLE
Fix NRE during remote AVG over empty data

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
@@ -310,6 +310,28 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(nullsExpectation, DataSourceLoader.Load(nulls, loadOptions).summary);
         }
 
+        [Fact]
+        public void Summary_Empty() {
+            // https://stackoverflow.com/a/1122839
+            // See also AggregateCalculatorTests.Calculation_Empty
+
+            var loadResult = DataSourceLoader.Load(new object[0], new SampleLoadOptions {
+                RemoteGrouping = true,
+                TotalSummary = new[] {
+                    new SummaryInfo { Selector = "any", SummaryType = "sum" },
+                    new SummaryInfo { Selector = "any", SummaryType = "min" },
+                    new SummaryInfo { Selector = "any", SummaryType = "max" },
+                    new SummaryInfo { Selector = "any", SummaryType = "avg" },
+                    new SummaryInfo { Selector = "any", SummaryType = "count" }
+                }
+            });
+
+            Assert.Equal(
+                new object[] { null, null, null, null, 0 },
+                loadResult.summary
+            );
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs
@@ -23,13 +23,7 @@ namespace DevExtreme.AspNet.Data.Aggregation {
         }
 
         public override object Finish() {
-            var count = (decimal)_countAggregator.Finish();
-            var value = _valueAggregator.Finish();
-
-            if(count == 0m)
-                return null;
-
-            return (decimal)value / count;
+            return (decimal?)_valueAggregator.Finish() / (decimal?)_countAggregator.Finish();
         }
     }
 


### PR DESCRIPTION
Invalid casting `null` to `decimal`:
https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/9de39ac3b2cb332c4f98ebc8d141ed9e51030d68/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs#L26

Nullable division produces `null` when either of the operands is `null`. Details: https://stackoverflow.com/a/3370150.