### PR TITLE
Add .NET Standard 1.3 target

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.Common/DevExtreme.AspNet.Data.Tests.Common.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests.Common/DevExtreme.AspNet.Data.Tests.Common.csproj
@@ -7,11 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DevExtreme.AspNet.Data\DevExtreme.AspNet.Data.csproj" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.1.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/net/DevExtreme.AspNet.Data/DevExtreme.AspNet.Data.csproj
+++ b/net/DevExtreme.AspNet.Data/DevExtreme.AspNet.Data.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <AssemblyName>DevExtreme.AspNet.Data</AssemblyName>
     <AssemblyVersion>99.0</AssemblyVersion>
-    <TargetFrameworks>net40;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.0;netstandard1.3</TargetFrameworks>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45</PackageTargetFallback>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <DebugType>full</DebugType>
@@ -22,14 +22,11 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="5.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Newtonsoft.Json" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
@@ -40,6 +37,14 @@
     <PackageReference Include="System.Text.RegularExpressions" Version="4.0.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="5.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
+    <PackageReference Include="System.Linq.Queryable" Version="4.0.1" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #249

New target is needed because of [System.Reflection.TypeExtensions](https://www.nuget.org/packages/System.Reflection.TypeExtensions/) which doesn't support lower versions of .NET Standard.

For testing use NuGet from
https://ci.appveyor.com/project/AlekseyMartynov/devextreme-aspnet-data/build/311/artifacts