### PR TITLE
Fix T640117

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.EF6/DevExtreme.AspNet.Data.Tests.EF6.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/DevExtreme.AspNet.Data.Tests.EF6.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Bug239.cs" />
     <Compile Include="Bug240.cs" />
     <Compile Include="SelectNotMapped.cs" />
+    <Compile Include="T640117.cs" />
     <Compile Include="TestDbContext.cs" />
     <Compile Include="Bug112.cs" />
   </ItemGroup>

--- a/net/DevExtreme.AspNet.Data.Tests.EF6/T640117.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/T640117.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity;
+using System.Linq;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests.EF6 {
+
+    class T640117_ParentItem {
+
+        public T640117_ParentItem() {
+            Children = new HashSet<T640117_ChildItem>();
+        }
+
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public int ID { get; set; }
+
+        [ForeignKey("ParentID")]
+        public ICollection<T640117_ChildItem> Children { get; set; }
+    }
+
+    class T640117_ChildItem {
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public int ID { get; set; }
+
+        public int? ParentID { get; set; }
+
+        public T640117_ParentItem Parent { get; set; }
+    }
+
+    partial class TestDbContext {
+        public DbSet<T640117_ParentItem> T640117_Parents { get; set; }
+        public DbSet<T640117_ChildItem> T640117_Children { get; set; }
+    }
+
+    public class T640117 {
+
+        [Fact]
+        public void Scenario() {
+            TestDbContext.Exec(context => {
+                var parent = new T640117_ParentItem { ID = 123 };
+                var child = new T640117_ChildItem { ID = 1 };
+                var orphan = new T640117_ChildItem { ID = 2 };
+
+                parent.Children.Add(child);
+                context.T640117_Parents.Add(parent);
+                context.T640117_Children.Add(orphan);
+                context.SaveChanges();
+
+                {
+                    var loadResut = DataSourceLoader.Load(context.T640117_Children, new SampleLoadOptions {
+                        Select = new[] { "Parent.ID" },
+                        Sort = new[] {
+                            new SortingInfo { Selector = "Parent.ID" }
+                        }
+                    });
+
+                    dynamic items = loadResut.data.Cast<object>().ToArray();
+                    Assert.Null(items[0].Parent.ID);
+                    Assert.Equal(123, items[1].Parent.ID);
+                }
+
+                {
+                    var loadResult = DataSourceLoader.Load(context.T640117_Children, new SampleLoadOptions {
+                        Filter = new[] { "Parent.ID", null }
+                    });
+
+                    Assert.Single(loadResult.data);
+                }
+
+                {
+                    var loadResult = DataSourceLoader.Load(context.T640117_Children, new SampleLoadOptions {
+                        Filter = new[] { "Parent.ID", "<>", null }
+                    });
+
+                    Assert.Single(loadResult.data);
+                }
+            });
+        }
+    }
+}
+
+

--- a/net/DevExtreme.AspNet.Data.Tests.EF6/T640117.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EF6/T640117.cs
@@ -76,6 +76,14 @@ namespace DevExtreme.AspNet.Data.Tests.EF6 {
 
                     Assert.Single(loadResult.data);
                 }
+
+                {
+                    var loadResult = DataSourceLoader.Load(context.T640117_Children, new SampleLoadOptions {
+                        Filter = new[] { "ID", null }
+                    });
+
+                    Assert.Empty(loadResult.data);
+                }
             });
         }
     }

--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
@@ -278,8 +278,10 @@ namespace DevExtreme.AspNet.Data.Tests {
                 return Compile<Tuple<int>>(new[] { "Item1", op, null }).Body.ToString();
             }
 
-            Assert.Equal("False", CompileOperation("="));
-            Assert.Equal("True", CompileOperation("<>"));
+            var expectedConvert = Compat.ExpectedConvert("obj.Item1", "Nullable`1");
+
+            Assert.Equal($"({expectedConvert} == null)", CompileOperation("="));
+            Assert.Equal($"({expectedConvert} != null)", CompileOperation("<>"));
 
             // https://stackoverflow.com/q/4399932
             Assert.Equal("False", CompileOperation(">"));

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -52,7 +52,7 @@ namespace DevExtreme.AspNet.Data {
                 var lastIndex = progression.Count - 1;
                 var last = progression[lastIndex];
                 if(Utils.CanAssignNull(target.Type) && !Utils.CanAssignNull(last.Type))
-                    progression[lastIndex] = Expression.Convert(last, typeof(Nullable<>).MakeGenericType(last.Type));
+                    progression[lastIndex] = Expression.Convert(last, Utils.MakeNullable(last.Type));
             }
 
             return CompileNullGuard(progression);

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -66,15 +66,16 @@ namespace DevExtreme.AspNet.Data {
 
                 if(clientValue == null && !Utils.CanAssignNull(accessorExpr.Type)) {
                     switch(expressionType) {
-                        case ExpressionType.NotEqual:
-                            return Expression.Constant(true);
-
-                        case ExpressionType.Equal:
                         case ExpressionType.GreaterThan:
                         case ExpressionType.GreaterThanOrEqual:
                         case ExpressionType.LessThan:
                         case ExpressionType.LessThanOrEqual:
                             return Expression.Constant(false);
+
+                        case ExpressionType.Equal:
+                        case ExpressionType.NotEqual:
+                            accessorExpr = Expression.Convert(accessorExpr, Utils.MakeNullable(accessorExpr.Type));
+                            break;
                     }
                 }
 

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
@@ -171,7 +171,7 @@ namespace DevExtreme.AspNet.Data.RemoteGrouping {
             }
 
             if(nullable)
-                type = typeof(Nullable<>).MakeGenericType(type);
+                return Utils.MakeNullable(type);
 
             return type;
         }

--- a/net/DevExtreme.AspNet.Data/Utils.cs
+++ b/net/DevExtreme.AspNet.Data/Utils.cs
@@ -20,6 +20,10 @@ namespace DevExtreme.AspNet.Data {
             return info.IsGenericType && info.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
+        public static Type MakeNullable(Type type) {
+            return typeof(Nullable<>).MakeGenericType(type);
+        }
+
         public static object GetDefaultValue(Type type) {
             if(type.GetTypeInfo().IsValueType)
                 return Activator.CreateInstance(type);


### PR DESCRIPTION
Reported in https://devexpress.com/issue=T640117

Changes from https://github.com/DevExpress/DevExtreme.AspNet.Data/pull/234 don't work well with nested (parent-child) members.

SQL example:

|ID|ParentID|
|--|--|
|2|NULL|
|1|123|

Equality comparison with `null` has `IS NULL` semantics. Both queries below return a single row:

```sql
select * from Table where ParentID is null;
select * from Table where ParentID is not null;
```
ORM expressions like `item.Parent.ID == null` must work even though `ID`, being the primary key, is not nullable: 

![](https://user-images.githubusercontent.com/4426185/40840797-cf8809bc-65b0-11e8-9219-945b0e276efd.png)


To achieve this, conversion to `Nullable` is now used instead of interrupting.

Inequality operators (`? < null`, etc) always evaluate to `false`, [in CLR](https://stackoverflow.com/q/4399932) and [in SQL](https://www.w3schools.com/sql/sql_null_values.asp), so the related code is kept intact.


cc @GoshaFighten @vconst 

