### PR TITLE
Fix Group.summary=[] when RemoteGrouping=true

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -203,6 +203,36 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(2, groups[0].count);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Load_EmptySummary(bool remoteGrouping) {
+            var data = new[] {
+                new { g = 1 }
+            };
+
+            var loadOptions = new SampleLoadOptions {
+                RemoteGrouping = remoteGrouping,
+                Group = new[] {
+                    new GroupingInfo { Selector = "g", IsExpanded = false }
+                }
+            };
+
+            void Run() {
+                var loadResult = DataSourceLoader.Load(data, loadOptions);
+                Assert.Null(loadResult.summary);
+                Assert.Null(loadResult.data.Cast<Group>().First().summary);
+            }
+
+            Assert.Null(loadOptions.TotalSummary);
+            Assert.Null(loadOptions.GroupSummary);
+            Run();
+
+            loadOptions.TotalSummary = Array.Empty<SummaryInfo>();
+            loadOptions.GroupSummary = Array.Empty<SummaryInfo>();
+            Run();
+        }
+
         [Fact]
         public void RequireGroupCountWhenGroupsAreExpanded() {
             var data = new[] {

--- a/net/DevExtreme.AspNet.Data/Aggregation/AggregateCalculator.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/AggregateCalculator.cs
@@ -23,14 +23,16 @@ namespace DevExtreme.AspNet.Data.Aggregation {
         public AggregateCalculator(IEnumerable data, IAccessor<T> accessor, IList<SummaryInfo> totalSummary, IList<SummaryInfo> groupSummary, SumFix sumFix = null) {
             _data = data;
             _accessor = accessor;
-            _totalSummary = totalSummary;
-            _groupSummary = groupSummary;
             _sumFix = sumFix ?? new SumFix(typeof(T), totalSummary, groupSummary);
 
-            _totalAggregators = _totalSummary?.Select(CreateAggregator).ToArray();
+            if(totalSummary != null && totalSummary.Count > 0)
+                _totalAggregators = totalSummary.Select(CreateAggregator).ToArray();
 
-            if(groupSummary != null)
+            if(groupSummary != null && groupSummary.Count > 0)
                 _groupAggregatorsStack = new Stack<Aggregator<T>[]>();
+
+            _totalSummary = totalSummary;
+            _groupSummary = groupSummary;
         }
 
         public object[] Run() {

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupTransformer.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupTransformer.cs
@@ -29,6 +29,7 @@ namespace DevExtreme.AspNet.Data.RemoteGrouping {
             var transformedTotalSummary = TransformSummary(totalSummary, ref fieldIndex);
             var transformedGroupSummary = TransformSummary(groupSummary, ref fieldIndex);
 
+            transformedTotalSummary = transformedTotalSummary ?? new List<SummaryInfo>();
             transformedTotalSummary.Add(new SummaryInfo { SummaryType = AggregateName.REMOTE_COUNT });
 
             var sumFix = new SumFix(sourceItemType, totalSummary, groupSummary);
@@ -47,9 +48,10 @@ namespace DevExtreme.AspNet.Data.RemoteGrouping {
         }
 
         static List<SummaryInfo> TransformSummary(SummaryInfo[] original, ref int fieldIndex) {
-            var result = new List<SummaryInfo>();
             if(original == null)
-                return result;
+                return null;
+
+            var result = new List<SummaryInfo>();
 
             for(var originalIndex = 0; originalIndex < original.Length; originalIndex++) {
                 var originalType = original[originalIndex].SummaryType;


### PR DESCRIPTION
Currently, with `RemoteGrouping = true` groups always have `summary: []` which is useless and increases JSON payloads.