### PR TITLE
Use GroupBy(const) for total summary

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.L2S/DevExtreme.AspNet.Data.Tests.L2S.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests.L2S/DevExtreme.AspNet.Data.Tests.L2S.csproj
@@ -88,6 +88,7 @@
   <ItemGroup>
     <Compile Include="RemoteGroupingStress.cs" />
     <Compile Include="Summary.cs" />
+    <Compile Include="T670222_TotalSummary.cs" />
     <Compile Include="TestDataClasses.cs">
       <DependentUpon>TestDataClasses.dbml</DependentUpon>
     </Compile>

--- a/net/DevExtreme.AspNet.Data.Tests.L2S/T670222_TotalSummary.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.L2S/T670222_TotalSummary.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests.L2S {
+
+    public class T670222_TotalSummary {
+
+        [Fact]
+        public void Scenario() {
+            TestDataContext.Exec(context => {
+                context.PurgeGenericTestTable();
+
+                var table = context.GenericTestDataItems;
+                table.InsertOnSubmit(new GenericTestDataItem { Num = 1 });
+                table.InsertOnSubmit(new GenericTestDataItem { Num = 2 });
+                context.SubmitChanges();
+
+                var loadResult = DataSourceLoader.Load(table, new SampleLoadOptions {
+                    TotalSummary = new[] {
+                        new SummaryInfo { Selector = "Num", SummaryType = "sum" }
+                    }
+                });
+
+                Assert.Equal(3m, loadResult.summary[0]);
+            });
+        }
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.cs
@@ -33,12 +33,22 @@ namespace DevExtreme.AspNet.Data.Tests.L2S {
                             {nameof(Summary_DataItem.Value)} int
                         )"
                     );
+
+                    INSTANCE.ExecuteCommand(
+                        $@"create table {nameof(GenericTestDataItem)} (
+                            {nameof(GenericTestDataItem.ID)} int identity primary key,
+                            {nameof(GenericTestDataItem.Num)} int
+                        )"
+                    );
                 }
 
                 action(INSTANCE);
             }
         }
 
+        public void PurgeGenericTestTable() {
+            ExecuteCommand("delete from " + nameof(GenericTestDataItem));
+        }
     }
 
     partial class RemoteGroupingStress_DataItem : RemoteGroupingStressHelper.IEntity {

--- a/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.dbml
+++ b/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.dbml
@@ -16,4 +16,10 @@
       <Column Name="Value" Type="System.Int32" CanBeNull="true" />
     </Type>
   </Table>
+  <Table Name="" Member="GenericTestDataItems">
+    <Type Name="GenericTestDataItem">
+      <Column Member="ID" AutoSync="Never" Type="System.Int32" IsPrimaryKey="true" IsDbGenerated="true" CanBeNull="false" />
+      <Column Member="Num" Type="System.Int32" CanBeNull="false" />
+    </Type>
+  </Table>
 </Database>

--- a/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.dbml.layout
+++ b/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.dbml.layout
@@ -14,5 +14,11 @@
         <elementListCompartment Id="672e9425-153a-4b0e-a766-7a2ce04a4891" absoluteBounds="3.39, 0.96, 1.9700000000000002, 1.0185953776041665" name="DataPropertiesCompartment" titleTextColor="Black" itemTextColor="Black" />
       </nestedChildShapes>
     </classShape>
+    <classShape Id="3138401b-5897-40ce-ab0f-264a360d93fa" absoluteBounds="5.875, 0.5, 2, 1.1939925130208333">
+      <DataClassMoniker Name="/TestDataContext/GenericTestDataItem" />
+      <nestedChildShapes>
+        <elementListCompartment Id="54b2396d-6c48-4d3f-8074-692608ab89a7" absoluteBounds="5.89, 0.96, 1.9700000000000002, 0.63399251302083326" name="DataPropertiesCompartment" titleTextColor="Black" itemTextColor="Black" />
+      </nestedChildShapes>
+    </classShape>
   </nestedChildShapes>
 </ordesignerObjectsDiagram>

--- a/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.designer.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.L2S/TestDataClasses.designer.cs
@@ -35,6 +35,9 @@ namespace DevExtreme.AspNet.Data.Tests.L2S
     partial void InsertSummary_DataItem(Summary_DataItem instance);
     partial void UpdateSummary_DataItem(Summary_DataItem instance);
     partial void DeleteSummary_DataItem(Summary_DataItem instance);
+    partial void InsertGenericTestDataItem(GenericTestDataItem instance);
+    partial void UpdateGenericTestDataItem(GenericTestDataItem instance);
+    partial void DeleteGenericTestDataItem(GenericTestDataItem instance);
     #endregion
 		
 		public TestDataContext(string connection) : 
@@ -74,6 +77,14 @@ namespace DevExtreme.AspNet.Data.Tests.L2S
 			get
 			{
 				return this.GetTable<Summary_DataItem>();
+			}
+		}
+		
+		public System.Data.Linq.Table<GenericTestDataItem> GenericTestDataItems
+		{
+			get
+			{
+				return this.GetTable<GenericTestDataItem>();
 			}
 		}
 	}
@@ -345,6 +356,92 @@ namespace DevExtreme.AspNet.Data.Tests.L2S
 					this._Value = value;
 					this.SendPropertyChanged("Value");
 					this.OnValueChanged();
+				}
+			}
+		}
+		
+		public event PropertyChangingEventHandler PropertyChanging;
+		
+		public event PropertyChangedEventHandler PropertyChanged;
+		
+		protected virtual void SendPropertyChanging()
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, emptyChangingEventArgs);
+			}
+		}
+		
+		protected virtual void SendPropertyChanged(String propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+	}
+	
+	[global::System.Data.Linq.Mapping.TableAttribute(Name="")]
+	public partial class GenericTestDataItem : INotifyPropertyChanging, INotifyPropertyChanged
+	{
+		
+		private static PropertyChangingEventArgs emptyChangingEventArgs = new PropertyChangingEventArgs(String.Empty);
+		
+		private int _ID;
+		
+		private int _Num;
+		
+    #region Extensibility Method Definitions
+    partial void OnLoaded();
+    partial void OnValidate(System.Data.Linq.ChangeAction action);
+    partial void OnCreated();
+    partial void OnIDChanging(int value);
+    partial void OnIDChanged();
+    partial void OnNumChanging(int value);
+    partial void OnNumChanged();
+    #endregion
+		
+		public GenericTestDataItem()
+		{
+			OnCreated();
+		}
+		
+		[global::System.Data.Linq.Mapping.ColumnAttribute(Storage="_ID", IsPrimaryKey=true, IsDbGenerated=true)]
+		public int ID
+		{
+			get
+			{
+				return this._ID;
+			}
+			set
+			{
+				if ((this._ID != value))
+				{
+					this.OnIDChanging(value);
+					this.SendPropertyChanging();
+					this._ID = value;
+					this.SendPropertyChanged("ID");
+					this.OnIDChanged();
+				}
+			}
+		}
+		
+		[global::System.Data.Linq.Mapping.ColumnAttribute(Storage="_Num")]
+		public int Num
+		{
+			get
+			{
+				return this._Num;
+			}
+			set
+			{
+				if ((this._Num != value))
+				{
+					this.OnNumChanging(value);
+					this.SendPropertyChanging();
+					this._Num = value;
+					this.SendPropertyChanged("Num");
+					this.OnNumChanged();
 				}
 			}
 		}

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -86,7 +86,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             var expr = new RemoteGroupExpressionCompiler<DataItem>(null, null, null).Compile(CreateTargetParam<DataItem>());
             Assert.Equal(
                 "data"
-                    + ".GroupBy(obj => new AnonType())"
+                    + ".GroupBy(obj => 1)"
                     + ".Select(g => new AnonType`1(I0 = g.Count()))",
                 expr.ToString()
             );

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
@@ -146,7 +146,8 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Contains("Take", loadOptions.ExpressionLog[0]);
 
             // 2 - load summaries
-            Assert.Contains("AnonType()", loadOptions.ExpressionLog[1]);
+            Assert.Contains(".GroupBy(", loadOptions.ExpressionLog[1]);
+            Assert.Contains(".Sum(", loadOptions.ExpressionLog[1]);
 
             Assert.Equal(4M, result.summary[0]);
             Assert.Single(result.data.Cast<object>());

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteGroupExpressionCompiler.cs
@@ -44,7 +44,14 @@ namespace DevExtreme.AspNet.Data.RemoteGrouping {
                 }
             }
 
-            var groupKeyLambda = Expression.Lambda(AnonType.CreateNewExpression(groupKeyExprList), groupByParam);
+            Expression CreateGroupKeyLambdaBody() {
+                if(groupKeyExprList.Count < 1)
+                    return Expression.Constant(1);
+
+                return AnonType.CreateNewExpression(groupKeyExprList);
+            }
+
+            var groupKeyLambda = Expression.Lambda(CreateGroupKeyLambdaBody(), groupByParam);
             var groupingType = typeof(IGrouping<,>).MakeGenericType(groupKeyLambda.ReturnType, typeof(T));
 
             target = Expression.Call(typeof(Queryable), nameof(Queryable.GroupBy), new[] { typeof(T), groupKeyLambda.ReturnType }, target, Expression.Quote(groupKeyLambda));


### PR DESCRIPTION
https://devexpress.com/issue=T670222 (see the comment by DMITRY PESTOV)

LINQ 2 SQL cannot handle `GroupBy(obj => new { })` used for total summary queries.

Related:
- https://github.com/aspnet/EntityFrameworkCore/issues/11905
- https://github.com/DevExpress/DevExtreme.AspNet.Data/commit/5030e3526c696fa387e4a28ca5c98ca4c56f5f1d