### PR TITLE
Optional ToLower() for string filters

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
@@ -51,42 +51,42 @@ namespace DevExtreme.AspNet.Data.Tests {
         [Fact]
         public void StringContains() {
             var expr = Compile<DataItem1>(new[] { "StringProp", "contains", "Abc" });
-            Assert.Equal("obj.StringProp.ToLower().Contains(\"abc\")", expr.Body.ToString());
+            Assert.Equal("obj.StringProp.Contains(\"Abc\")", expr.Body.ToString());
         }
 
         [Fact]
         public void StringNotContains() {
             var expr = Compile<DataItem1>(new[] { "StringProp", "notContains", "Abc" });
-            Assert.Equal("Not(obj.StringProp.ToLower().Contains(\"abc\"))", expr.Body.ToString());
+            Assert.Equal("Not(obj.StringProp.Contains(\"Abc\"))", expr.Body.ToString());
         }
 
         [Fact]
         public void StartsWith() {
             var expr = Compile<DataItem1>(new[] { "StringProp", "startsWith", "Prefix" });
-            Assert.Equal("obj.StringProp.ToLower().StartsWith(\"prefix\")", expr.Body.ToString());
+            Assert.Equal("obj.StringProp.StartsWith(\"Prefix\")", expr.Body.ToString());
         }
 
         [Fact]
         public void EndsWith() {
             var expr = Compile<DataItem1>(new[] { "StringProp", "endsWith", "Postfix" });
-            Assert.Equal("obj.StringProp.ToLower().EndsWith(\"postfix\")", expr.Body.ToString());
+            Assert.Equal("obj.StringProp.EndsWith(\"Postfix\")", expr.Body.ToString());
         }
 
         [Fact]
         public void StringFunctionOnNonStringData() {
             var expr = Compile<DataItem1>(new[] { "IntProp", "contains", "Abc" });
-            Assert.Equal("obj.IntProp.ToString().ToLower().Contains(\"abc\")", expr.Body.ToString());
+            Assert.Equal("obj.IntProp.ToString().Contains(\"Abc\")", expr.Body.ToString());
         }
 
         [Fact]
         public void StringFunctionGuardNulls() {
             Assert.Equal(
-                @"(IIF((obj == null), null, obj.StringProp) ?? """").ToLower().StartsWith(""abc"")",
+                @"(IIF((obj == null), null, obj.StringProp) ?? """").StartsWith(""abc"")",
                 Compile<DataItem1>(new[] { "StringProp", "startswith", "abc" }, true).Body.ToString()
             );
 
             Assert.Equal(
-                @"(IIF((obj == null), null, obj.IntProp.ToString()) ?? """").ToLower().StartsWith(""abc"")",
+                @"(IIF((obj == null), null, obj.IntProp.ToString()) ?? """").StartsWith(""abc"")",
                 Compile<DataItem1>(new[] { "IntProp", "startswith", "abc" }, true).Body.ToString()
             );
         }

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -21,6 +21,21 @@ namespace DevExtreme.AspNet.Data.Tests {
             AssertFilter<string>(false, true, op, expectedExpr);
         }
 
+        [Theory]
+        [InlineData("=", "(obj == 'T')")]
+        [InlineData("<>", "(obj != 'T')")]
+        [InlineData(">", "(Compare(obj, 'T') > 0)")]
+        [InlineData("<", "(Compare(obj, 'T') < 0)")]
+        [InlineData(">=", "(Compare(obj, 'T') >= 0)")]
+        [InlineData("<=", "(Compare(obj, 'T') <= 0)")]
+        [InlineData("startswith", "obj.StartsWith('T')")]
+        [InlineData("endswith", "obj.EndsWith('T')")]
+        [InlineData("contains", "obj.Contains('T')")]
+        [InlineData("notcontains", "Not(obj.Contains('T'))")]
+        public void False(string op, string expectedExpr) {
+            AssertFilter<string>(false, false, op, expectedExpr);
+        }
+
         [Fact]
         public void ImplicitTrueForL2O() {
             var loadResult = DataSourceLoader.Load(new[] { "T" }, new SampleLoadOptions {

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -36,6 +36,32 @@ namespace DevExtreme.AspNet.Data.Tests {
             AssertFilter<int?>(true, true, "contains", "(IIF((obj == null), null, obj.ToString().ToLower()) ?? '').Contains('t')");
         }
 
+        [Fact]
+        public void Dynamic() {
+            var compiler = new FilterExpressionCompiler<dynamic>(true, true);
+            var expr = compiler.Compile(new object[] {
+                new[] { "this", "startswith", "1" },
+                "or",
+                new[] { "this", "b" },
+                "or",
+                new[] { "this", ">=", "c" }
+            });
+
+            var expectedExpr = "(((IIF((obj == null), null, obj.ToString().ToLower()) ?? '').StartsWith('1')"
+                    + " OrElse (IIF((obj == null), null, obj.ToString().ToLower()) == 'b'))"
+                    + " OrElse (Compare(IIF((obj == null), null, obj.ToString().ToLower()), 'c') >= 0))";
+
+            Assert.Equal(
+                expectedExpr.Replace("'", "\""),
+                expr.Body.ToString()
+            );
+
+            var method = expr.Compile();
+            Assert.True((bool)method.DynamicInvoke(1));
+            Assert.True((bool)method.DynamicInvoke("b"));
+            Assert.True((bool)method.DynamicInvoke('c'));
+        }
+
         void AssertFilter<T>(bool guardNulls, bool stringToLower, string op, string expectedExpr) {
             expectedExpr = expectedExpr.Replace("'", "\"");
 

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -18,7 +18,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         [InlineData("contains", "obj.ToLower().Contains('t')")]
         [InlineData("notcontains", "Not(obj.ToLower().Contains('t'))")]
         public void True(string op, string expectedExpr) {
-            AssertFilter(false, true, op, expectedExpr);
+            AssertFilter<string>(false, true, op, expectedExpr);
         }
 
         [Fact]
@@ -31,12 +31,17 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(1, loadResult.totalCount);
         }
 
-        void AssertFilter(bool guardNulls, bool stringToLower, string op, string expectedExpr) {
+        [Fact]
+        public void ForceToString_ToLower_GuardNulls() {
+            AssertFilter<int?>(true, true, "contains", "(IIF((obj == null), null, obj.ToString().ToLower()) ?? '').Contains('t')");
+        }
+
+        void AssertFilter<T>(bool guardNulls, bool stringToLower, string op, string expectedExpr) {
             expectedExpr = expectedExpr.Replace("'", "\"");
 
             Assert.Equal(
                 expectedExpr,
-                new FilterExpressionCompiler<string>(guardNulls, stringToLower)
+                new FilterExpressionCompiler<T>(guardNulls, stringToLower)
                     .Compile(new[] { "this", op, "T" })
                     .Body.ToString()
             );

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class StringToLowerTests {
+
+        [Theory]
+        [InlineData("=", "(obj.ToLower() == 't')")]
+        [InlineData("<>", "(obj.ToLower() != 't')")]
+        [InlineData(">", "(Compare(obj.ToLower(), 't') > 0)")]
+        [InlineData("<", "(Compare(obj.ToLower(), 't') < 0)")]
+        [InlineData(">=", "(Compare(obj.ToLower(), 't') >= 0)")]
+        [InlineData("<=", "(Compare(obj.ToLower(), 't') <= 0)")]
+        [InlineData("startswith", "obj.ToLower().StartsWith('t')")]
+        [InlineData("endswith", "obj.ToLower().EndsWith('t')")]
+        [InlineData("contains", "obj.ToLower().Contains('t')")]
+        [InlineData("notcontains", "Not(obj.ToLower().Contains('t'))")]
+        public void True(string op, string expectedExpr) {
+            AssertFilter(false, true, op, expectedExpr);
+        }
+
+        [Fact]
+        public void ImplicitTrueForL2O() {
+            var loadResult = DataSourceLoader.Load(new[] { "T" }, new SampleLoadOptions {
+                Filter = new[] { "this", "t" },
+                IsCountQuery = true
+            });
+
+            Assert.Equal(1, loadResult.totalCount);
+        }
+
+        void AssertFilter(bool guardNulls, bool stringToLower, string op, string expectedExpr) {
+            expectedExpr = expectedExpr.Replace("'", "\"");
+
+            Assert.Equal(
+                expectedExpr,
+                new FilterExpressionCompiler<string>(guardNulls, stringToLower)
+                    .Compile(new[] { "this", op, "T" })
+                    .Body.ToString()
+            );
+        }
+
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -13,11 +13,13 @@ namespace DevExtreme.AspNet.Data {
     class DataSourceExpressionBuilder<T> {
         DataSourceLoadOptionsBase _loadOptions;
         bool _guardNulls;
+        bool _stringToLower;
         AnonTypeNewTweaks _anonTypeNewTweaks;
 
-        public DataSourceExpressionBuilder(DataSourceLoadOptionsBase loadOptions, bool guardNulls = false, AnonTypeNewTweaks anonTypeNewTweaks = null) {
+        public DataSourceExpressionBuilder(DataSourceLoadOptionsBase loadOptions, bool guardNulls = false, bool stringToLower = false, AnonTypeNewTweaks anonTypeNewTweaks = null) {
             _loadOptions = loadOptions;
             _guardNulls = guardNulls;
+            _stringToLower = stringToLower;
             _anonTypeNewTweaks = anonTypeNewTweaks;
         }
 
@@ -38,7 +40,7 @@ namespace DevExtreme.AspNet.Data {
             var genericTypeArguments = new[] { typeof(T) };
 
             if(_loadOptions.HasFilter)
-                expr = Expression.Call(queryableType, "Where", genericTypeArguments, expr, Expression.Quote(new FilterExpressionCompiler<T>(_guardNulls).Compile(_loadOptions.Filter)));
+                expr = Expression.Call(queryableType, "Where", genericTypeArguments, expr, Expression.Quote(new FilterExpressionCompiler<T>(_guardNulls, _stringToLower).Compile(_loadOptions.Filter)));
 
             if(!isCountQuery) {
                 if(!remoteGrouping) {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -95,6 +95,9 @@ namespace DevExtreme.AspNet.Data {
         /// </summary>
         public string DefaultSort { get; set; }
 
+#warning TODO docs
+        public bool? StringToLower { get; set; }
+
 #if DEBUG
         internal Action<Expression> ExpressionWatcher;
         internal bool UseEnumerableOnce;

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -25,10 +25,15 @@ namespace DevExtreme.AspNet.Data {
 
         public DataSourceLoaderImpl(IQueryable<S> source, DataSourceLoadOptionsBase options) {
             QueryProviderInfo = new QueryProviderInfo(source.Provider);
-            Builder = new DataSourceExpressionBuilder<S>(options, QueryProviderInfo.IsLinqToObjects, new AnonTypeNewTweaks {
-                AllowEmpty = !QueryProviderInfo.IsL2S,
-                AllowUnusedMembers = !QueryProviderInfo.IsL2S
-            });
+            Builder = new DataSourceExpressionBuilder<S>(
+                options,
+                QueryProviderInfo.IsLinqToObjects,
+                options.StringToLower.GetValueOrDefault(QueryProviderInfo.IsLinqToObjects),
+                new AnonTypeNewTweaks {
+                    AllowEmpty = !QueryProviderInfo.IsL2S,
+                    AllowUnusedMembers = !QueryProviderInfo.IsL2S
+                }
+            );
             ShouldEmptyGroups = options.HasGroups && !options.Group.Last().GetIsExpanded();
             CanUseRemoteGrouping = options.RemoteGrouping ?? ShouldUseRemoteGrouping(QueryProviderInfo, options);
             SummaryIsTotalCountOnly = !options.HasGroupSummary && options.HasSummary && options.TotalSummary.All(i => i.SummaryType == AggregateName.COUNT);

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -48,7 +48,7 @@ namespace DevExtreme.AspNet.Data {
             var isStringOperation = clientOperation == CONTAINS || clientOperation == NOT_CONTAINS || clientOperation == STARTS_WITH || clientOperation == ENDS_WITH;
 
             var accessorExpr = CompileAccessorExpression(dataItemExpr, clientAccessor, progression => {
-                if(isStringOperation)
+                if(isStringOperation || clientAccessor is String && progression.Last().Type == typeof(Object))
                     ForceToString(progression);
 
                 if(_stringToLower)

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -223,6 +223,9 @@ namespace DevExtreme.AspNet.Data {
             var toLowerMethod = typeof(String).GetMethod(nameof(String.ToLower), Type.EmptyTypes);
             var toLowerCall = Expression.Call(last, toLowerMethod);
 
+            if(last is MethodCallExpression lastCall && lastCall.Method.Name == nameof(ToString))
+                progression.RemoveAt(progression.Count - 1);
+
             progression.Add(toLowerCall);
         }
     }

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -103,9 +103,6 @@ namespace DevExtreme.AspNet.Data {
         }
 
         Expression CompileStringFunction(Expression accessorExpr, string clientOperation, string value) {
-            if(value != null)
-                value = value.ToLower();
-
             var invert = false;
 
             if(clientOperation == NOT_CONTAINS) {
@@ -116,14 +113,9 @@ namespace DevExtreme.AspNet.Data {
             if(GuardNulls)
                 accessorExpr = Expression.Coalesce(accessorExpr, Expression.Constant(""));
 
-            var toLowerMethod = typeof(String).GetMethod(nameof(String.ToLower), Type.EmptyTypes);
             var operationMethod = typeof(String).GetMethod(GetStringOperationMethodName(clientOperation), new[] { typeof(String) });
 
-            Expression result = Expression.Call(
-                Expression.Call(accessorExpr, toLowerMethod),
-                operationMethod,
-                Expression.Constant(value)
-            );
+            Expression result = Expression.Call(accessorExpr, operationMethod, Expression.Constant(value));
 
             if(invert)
                 result = Expression.Not(result);

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -91,9 +91,6 @@ namespace DevExtreme.AspNet.Data {
                 Expression valueExpr = Expression.Constant(clientValue, accessorExpr.Type);
 
                 if(accessorExpr.Type == typeof(String) && IsInequality(expressionType)) {
-                    if(clientValue == null)
-                        valueExpr = Expression.Constant(null, typeof(String));
-
                     var compareMethod = typeof(String).GetMethod(nameof(String.Compare), new[] { typeof(String), typeof(String) });
                     accessorExpr = Expression.Call(null, compareMethod, accessorExpr, valueExpr);
                     valueExpr = Expression.Constant(0);


### PR DESCRIPTION
This PR changes the translation of string filters to LINQ.

**Previously**:
- `StartsWith`, `EndsWith`, `Contains`, `NotContains` operators unconditionally apply `ToLower()` to both parts of binary expressions. Example:

    ```
    [ "Prop", "contains", "A" ]
    ```
    produces
    ```
    obj.Prop.ToLower().Contains("a")
    ```
- Comparison operators (`=`, `>`, etc) are translated without `ToLower()`.

**In this PR**:
- New `Nullable<bool> StringToLower` option in `DataSourceLoadOptionsBase` (*property name is preliminary*).
- It defaults to `true` for LINQ 2 Objects, `false` for any other provider. Rationale: string comparison is often governed by database collation settings.
- It affects all operators.

For 2.x only.
Needs to be filed as a potential breaking change in 2.0.

Closes #296 
