### PR TITLE
Don't use AnonType classes when RemoteSelect is False

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -437,6 +437,19 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Equal(1, item["a"]);
         }
 
+        [Fact]
+        public void Load_RemoteSelectFalse_NoAnonTypeLimits() {
+            var loadResult = DataSourceLoader.Load(new[] { "a" }, new SampleLoadOptions {
+                Select = Enumerable.Repeat("this", 123).ToArray(),
+                RemoteSelect = false
+            });
+
+            Assert.All(
+                loadResult.data.Cast<IDictionary<string, object>>(),
+                i => Assert.Equal("a", i["this"])
+            );
+        }
+
         [Theory]
         [InlineData(false, true)]
         [InlineData(false, false)]

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -6,10 +6,8 @@ using DevExtreme.AspNet.Data.Types;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace DevExtreme.AspNet.Data {
 
@@ -98,7 +96,7 @@ namespace DevExtreme.AspNet.Data {
 
                 if(Options.HasAnySelect) {
                     ContinueWithGrouping(
-                        ExecWithSelect(loadExpr).Select(ProjectionToExpando),
+                        ExecWithSelect(loadExpr),
                         result
                     );
                 } else {
@@ -118,13 +116,15 @@ namespace DevExtreme.AspNet.Data {
             return result;
         }
 
-        IEnumerable<AnonType> ExecWithSelect(Expression loadExpr) {
+        IEnumerable<IDictionary<string, object>> ExecWithSelect(Expression loadExpr) {
             if(Options.UseRemoteSelect)
-                return ExecExpr<AnonType>(Source, loadExpr);
+                return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(Source, loadExpr), Options.GetFullSelect());
 
             var inMemoryQuery = ForceExecution(ExecExpr<S>(Source, loadExpr)).AsQueryable();
             var selectExpr = new SelectExpressionCompiler<S>(true).Compile(inMemoryQuery.Expression, Options.GetFullSelect());
-            return ExecExpr<AnonType>(inMemoryQuery, selectExpr);
+
+            // TODO
+            return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(inMemoryQuery, selectExpr), Options.GetFullSelect());
         }
 
         void ContinueWithGrouping<R>(IEnumerable<R> loadResult, LoadResult result) {
@@ -236,30 +236,6 @@ namespace DevExtreme.AspNet.Data {
                 } else {
                     EmptyGroups(g.items, level - 1);
                 }
-            }
-        }
-
-        ExpandoObject ProjectionToExpando(AnonType projection) {
-            var expando = new ExpandoObject();
-            var index = 0;
-            foreach(var name in Options.GetFullSelect()) {
-                ShrinkSelectResult(expando, name.Split('.'), projection[index]);
-                index++;
-            }
-            return expando;
-        }
-
-        static void ShrinkSelectResult(IDictionary<string, object> target, string[] path, object value, int index = 0) {
-            var key = path[index];
-
-            if(index == path.Length - 1) {
-                target[key] = value;
-            } else {
-                if(!target.ContainsKey(key))
-                    target[key] = new ExpandoObject();
-
-                if(target[key] is IDictionary<string, object> child)
-                    ShrinkSelectResult(child, path, value, 1 + index);
             }
         }
     }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -117,14 +117,12 @@ namespace DevExtreme.AspNet.Data {
         }
 
         IEnumerable<IDictionary<string, object>> ExecWithSelect(Expression loadExpr) {
+            var select = Options.GetFullSelect();
+
             if(Options.UseRemoteSelect)
-                return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(Source, loadExpr), Options.GetFullSelect());
+                return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(Source, loadExpr), select);
 
-            var inMemoryQuery = ForceExecution(ExecExpr<S>(Source, loadExpr)).AsQueryable();
-            var selectExpr = new SelectExpressionCompiler<S>(true).Compile(inMemoryQuery.Expression, Options.GetFullSelect());
-
-            // TODO
-            return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(inMemoryQuery, selectExpr), Options.GetFullSelect());
+            return SelectHelper.Evaluate(ExecExpr<S>(Source, loadExpr), select);
         }
 
         void ContinueWithGrouping<R>(IEnumerable<R> loadResult, LoadResult result) {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -6,6 +6,7 @@ using DevExtreme.AspNet.Data.Types;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -116,7 +117,7 @@ namespace DevExtreme.AspNet.Data {
             return result;
         }
 
-        IEnumerable<IDictionary<string, object>> ExecWithSelect(Expression loadExpr) {
+        IEnumerable<ExpandoObject> ExecWithSelect(Expression loadExpr) {
             var select = Options.GetFullSelect();
 
             if(Options.UseRemoteSelect)

--- a/net/DevExtreme.AspNet.Data/SelectHelper.cs
+++ b/net/DevExtreme.AspNet.Data/SelectHelper.cs
@@ -9,21 +9,21 @@ namespace DevExtreme.AspNet.Data {
 
     static class SelectHelper {
 
-        public static IEnumerable<IDictionary<string, object>> Evaluate<T>(IEnumerable<T> data, IEnumerable<string> names) {
+        public static IEnumerable<ExpandoObject> Evaluate<T>(IEnumerable<T> data, IEnumerable<string> names) {
             var bufferedNames = names.ToArray();
             var accessor = new DefaultAccessor<T>();
 
             foreach(var item in data) {
-                IDictionary<string, object> expando = new ExpandoObject();
+                var expando = new ExpandoObject();
 
                 foreach(var name in bufferedNames)
-                    expando[name] = accessor.Read(item, name);
+                    (expando as IDictionary<string, object>)[name] = accessor.Read(item, name);
 
                 yield return expando;
             }
         }
 
-        public static IEnumerable<IDictionary<string, object>> ConvertRemoteResult(IEnumerable<AnonType> selectResult, IEnumerable<string> names) {
+        public static IEnumerable<ExpandoObject> ConvertRemoteResult(IEnumerable<AnonType> selectResult, IEnumerable<string> names) {
             var paths = names.Select(n => n.Split('.')).ToArray();
 
             foreach(var anonObj in selectResult) {

--- a/net/DevExtreme.AspNet.Data/SelectHelper.cs
+++ b/net/DevExtreme.AspNet.Data/SelectHelper.cs
@@ -15,9 +15,10 @@ namespace DevExtreme.AspNet.Data {
 
             foreach(var item in data) {
                 var expando = new ExpandoObject();
+                var dict = (IDictionary<string, object>)expando;
 
                 foreach(var name in bufferedNames)
-                    (expando as IDictionary<string, object>)[name] = accessor.Read(item, name);
+                    dict[name] = accessor.Read(item, name);
 
                 yield return expando;
             }

--- a/net/DevExtreme.AspNet.Data/SelectHelper.cs
+++ b/net/DevExtreme.AspNet.Data/SelectHelper.cs
@@ -1,4 +1,5 @@
-﻿using DevExtreme.AspNet.Data.Types;
+﻿using DevExtreme.AspNet.Data.Helpers;
+using DevExtreme.AspNet.Data.Types;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -7,6 +8,20 @@ using System.Linq;
 namespace DevExtreme.AspNet.Data {
 
     static class SelectHelper {
+
+        public static IEnumerable<IDictionary<string, object>> Evaluate<T>(IEnumerable<T> data, IEnumerable<string> names) {
+            var bufferedNames = names.ToArray();
+            var accessor = new DefaultAccessor<T>();
+
+            foreach(var item in data) {
+                IDictionary<string, object> expando = new ExpandoObject();
+
+                foreach(var name in bufferedNames)
+                    expando[name] = accessor.Read(item, name);
+
+                yield return expando;
+            }
+        }
 
         public static IEnumerable<IDictionary<string, object>> ConvertRemoteResult(IEnumerable<AnonType> selectResult, IEnumerable<string> names) {
             var paths = names.Select(n => n.Split('.')).ToArray();

--- a/net/DevExtreme.AspNet.Data/SelectHelper.cs
+++ b/net/DevExtreme.AspNet.Data/SelectHelper.cs
@@ -1,0 +1,40 @@
+﻿using DevExtreme.AspNet.Data.Types;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+
+namespace DevExtreme.AspNet.Data {
+
+    static class SelectHelper {
+
+        public static IEnumerable<IDictionary<string, object>> ConvertRemoteResult(IEnumerable<AnonType> selectResult, IEnumerable<string> names) {
+            var paths = names.Select(n => n.Split('.')).ToArray();
+
+            foreach(var anonObj in selectResult) {
+                var expando = new ExpandoObject();
+
+                for(var i = 0; i < paths.Length; i++)
+                    Shrink(expando, paths[i], anonObj[i]);
+
+                yield return expando;
+            }
+        }
+
+        static void Shrink(IDictionary<string, object> target, string[] path, object value, int index = 0) {
+            var key = path[index];
+
+            if(index == path.Length - 1) {
+                target[key] = value;
+            } else {
+                if(!target.ContainsKey(key))
+                    target[key] = new ExpandoObject();
+
+                if(target[key] is IDictionary<string, object> child)
+                    Shrink(child, path, value, 1 + index);
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
This removes the 32-item limit mentioned in #284.
