### PR TITLE
Intelligent default for RemoteSelect

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/Bug240Tests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/Bug240Tests.cs
@@ -16,6 +16,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                     new SortingInfo { Selector = selector }
                 },
                 Select = new[] { selector },
+                RemoteSelect = true,
                 Group = new[] {
                     new GroupingInfo { Selector = selector, IsExpanded = false }
                 },

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -448,7 +448,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         [Theory]
         [InlineData(false)]
         [InlineData(null)]
-        public void Load_RemoteSelectFalse_NoAnonTypeLimits(bool? remoteSelect) {
+        public void Load_Select_NoAnonTypeLimits(bool? remoteSelect) {
             var loadResult = DataSourceLoader.Load(new[] { "a" }, new SampleLoadOptions {
                 Select = Enumerable.Repeat("this", 123).ToArray(),
                 RemoteSelect = remoteSelect

--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -445,11 +445,13 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.True(item.ContainsKey("b"));
         }
 
-        [Fact]
-        public void Load_RemoteSelectFalse_NoAnonTypeLimits() {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void Load_RemoteSelectFalse_NoAnonTypeLimits(bool? remoteSelect) {
             var loadResult = DataSourceLoader.Load(new[] { "a" }, new SampleLoadOptions {
                 Select = Enumerable.Repeat("this", 123).ToArray(),
-                RemoteSelect = false
+                RemoteSelect = remoteSelect
             });
 
             Assert.All(

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -41,7 +41,7 @@ namespace DevExtreme.AspNet.Data {
                     if(_context.HasAnySort)
                         expr = new SortExpressionCompiler<T>(_guardNulls).Compile(expr, _context.GetFullSort());
                     if(_context.HasAnySelect && _context.UseRemoteSelect) {
-                        expr = new SelectExpressionCompiler<T>(_guardNulls).Compile(expr, _context.GetFullSelect());
+                        expr = new SelectExpressionCompiler<T>(_guardNulls).Compile(expr, _context.FullSelect);
                         genericTypeArguments = expr.Type.GetGenericArguments();
                     }
                 } else {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -86,12 +86,10 @@ namespace DevExtreme.AspNet.Data {
         }
 
         IEnumerable<ExpandoObject> ExecWithSelect(Expression loadExpr) {
-            var select = Context.GetFullSelect();
-
             if(Context.UseRemoteSelect)
-                return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(Source, loadExpr), select);
+                return SelectHelper.ConvertRemoteResult(ExecExpr<AnonType>(Source, loadExpr), Context.FullSelect);
 
-            return SelectHelper.Evaluate(ExecExpr<S>(Source, loadExpr), select);
+            return SelectHelper.Evaluate(ExecExpr<S>(Source, loadExpr), Context.FullSelect);
         }
 
         void ContinueWithGrouping<R>(IEnumerable<R> loadResult, LoadResult result) {

--- a/net/DevExtreme.AspNet.Data/Types/AnonType.Generated.cs
+++ b/net/DevExtreme.AspNet.Data/Types/AnonType.Generated.cs
@@ -399,7 +399,7 @@ namespace DevExtreme.AspNet.Data.Types {
     }
 
     partial class AnonType {
-        const int MAX_SIZE = 32;
+        internal const int MAX_SIZE = 32;
 
         static Type GetTemplate(int size) {
             if(size == 1) return typeof(AnonType<>);

--- a/net/DevExtreme.AspNet.Data/Types/AnonType.Generated.tt
+++ b/net/DevExtreme.AspNet.Data/Types/AnonType.Generated.tt
@@ -43,7 +43,7 @@ namespace DevExtreme.AspNet.Data.Types {
 <# } #>
 
     partial class AnonType {
-        const int MAX_SIZE = <#= SIZES.Max() #>;
+        internal const int MAX_SIZE = <#= SIZES.Max() #>;
 
         static Type GetTemplate(int size) {
 <# foreach(var size in SIZES) { #>


### PR DESCRIPTION
Previously:

```c#
RemoteSelect.GetValueOrDefault(true);
```

In this PR:

- `False` for LINQ 2 Objects
- `False` when the number of items exceeds 32.
- `True` otherwise

Effectively, this change resolves https://github.com/DevExpress/DevExtreme.AspNet.Data/issues/284.

