### PR TITLE
Don't force dynamic values to String unless they are actually String

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -213,6 +213,28 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Single(loadResult.data);
         }
 
+        [Fact]
+        public void NoToStringForNumbers() {
+            var compiler = new FilterExpressionCompiler<dynamic>(false);
+
+            void Case(IList clientFilter, string expectedExpr, object trueTestValue) {
+                var expr = compiler.Compile(clientFilter);
+                Assert.Equal(expectedExpr, expr.Body.ToString());
+                Assert.True((bool)expr.Compile().DynamicInvoke(trueTestValue));
+            }
+
+            Case(
+                new object[] { "this", ">", new JValue(9) },
+                "(DynamicCompare(obj, 9) > 0)",
+                10
+            );
+
+            Case(
+                new object[] { "this", new JValue("a") },
+                @"(obj.ToString() == ""a"")",
+                "a"
+            );
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -48,7 +48,7 @@ namespace DevExtreme.AspNet.Data {
             var isStringOperation = clientOperation == CONTAINS || clientOperation == NOT_CONTAINS || clientOperation == STARTS_WITH || clientOperation == ENDS_WITH;
 
             var accessorExpr = CompileAccessorExpression(dataItemExpr, clientAccessor, progression => {
-                if(isStringOperation || clientAccessor is String && progression.Last().Type == typeof(Object))
+                if(isStringOperation || progression.Last().Type == typeof(Object) && Utils.UnwrapNewtonsoftValue(clientValue) is String)
                     ForceToString(progression);
 
                 if(_stringToLower)


### PR DESCRIPTION
See also, a [related test case](https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/d8065c4301bb768fea3541c23c400ba4b84e1bf6/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs#L54-L67)