### PR TITLE
Change StringToLower default to True

### DIFF
--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -44,7 +44,7 @@ namespace DevExtreme.AspNet.Data {
     partial class DataSourceLoadContext {
         public IList Filter => _options.Filter;
         public bool HasFilter => !IsEmptyList(_options.Filter);
-        public bool UseStringToLower => _options.StringToLower.GetValueOrDefault(_providerInfo.IsLinqToObjects);
+        public bool UseStringToLower => _options.StringToLower.GetValueOrDefault(true);
     }
 
     // Grouping

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -94,7 +94,6 @@ namespace DevExtreme.AspNet.Data {
 
         /// <summary>
         /// A flag that indicates whether filter expressions should include a ToLower() call that makes string comparison case-insensitive.
-        /// Defaults to true for LINQ to Objects, false for any other provider.
         /// </summary>
         public bool? StringToLower { get; set; }
 


### PR DESCRIPTION
In #298, I wrote:

> It defaults to `true` for LINQ 2 Objects, `false` for any other provider. Rationale: string comparison is often governed by database collation settings.

Turns out, some databases don't support case-insensitive collations.
Surprisingly, Postgres is among them:
- https://devexpress.com/issue=T701611
- https://stackoverflow.com/q/18807276
- https://stackoverflow.com/q/17422054
