### PR TITLE
Introduce StringToLowerDefault, a global switch

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.Common/StaticBarrier.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.Common/StaticBarrier.cs
@@ -15,6 +15,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 } finally {
                     CustomAggregators.Clear();
                     CustomAccessorCompilers.Clear();
+                    DataSourceLoader.StringToLowerDefault = null;
                 }
             }
 

--- a/net/DevExtreme.AspNet.Data.Tests.Common/StaticBarrier.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.Common/StaticBarrier.cs
@@ -15,7 +15,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 } finally {
                     CustomAggregators.Clear();
                     CustomAccessorCompilers.Clear();
-                    DataSourceLoader.StringToLowerDefault = null;
+                    DataSourceLoadOptionsBase.StringToLowerDefault = null;
                 }
             }
 

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -77,6 +77,18 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.True((bool)method.DynamicInvoke('c'));
         }
 
+        [Fact]
+        public void GlobalSwitch() {
+            StaticBarrier.Run(delegate {
+                var options = new SampleLoadOptions {
+                    Filter = new[] { "this", "contains", "A" }
+                };
+                DataSourceLoader.StringToLowerDefault = false;
+                DataSourceLoader.Load(new[] { "" }, options).data.Cast<object>().ToArray();
+                Assert.DoesNotContain(options.ExpressionLog, line => line.Contains("ToLower"));
+            });
+        }
+
         void AssertFilter<T>(bool guardNulls, bool stringToLower, string op, string expectedExpr) {
             expectedExpr = expectedExpr.Replace("'", "\"");
 

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -83,7 +83,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 var options = new SampleLoadOptions {
                     Filter = new[] { "this", "contains", "A" }
                 };
-                DataSourceLoader.StringToLowerDefault = false;
+                DataSourceLoadOptionsBase.StringToLowerDefault = false;
                 DataSourceLoader.Load(new[] { "" }, options).data.Cast<object>().ToArray();
                 Assert.DoesNotContain(options.ExpressionLog, line => line.Contains("ToLower"));
             });

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -44,7 +44,7 @@ namespace DevExtreme.AspNet.Data {
     partial class DataSourceLoadContext {
         public IList Filter => _options.Filter;
         public bool HasFilter => !IsEmptyList(_options.Filter);
-        public bool UseStringToLower => _options.StringToLower ?? DataSourceLoader.StringToLowerDefault ?? _providerInfo.IsLinqToObjects;
+        public bool UseStringToLower => _options.StringToLower ?? DataSourceLoadOptionsBase.StringToLowerDefault ?? _providerInfo.IsLinqToObjects;
     }
 
     // Grouping

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -44,7 +44,7 @@ namespace DevExtreme.AspNet.Data {
     partial class DataSourceLoadContext {
         public IList Filter => _options.Filter;
         public bool HasFilter => !IsEmptyList(_options.Filter);
-        public bool UseStringToLower => _options.StringToLower.GetValueOrDefault(_providerInfo.IsLinqToObjects);
+        public bool UseStringToLower => _options.StringToLower ?? DataSourceLoader.StringToLowerDefault ?? _providerInfo.IsLinqToObjects;
     }
 
     // Grouping

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -10,6 +10,11 @@ namespace DevExtreme.AspNet.Data {
     /// </summary>
     public class DataSourceLoadOptionsBase {
         /// <summary>
+        /// TODO
+        /// </summary>
+        public static bool? StringToLowerDefault { get; set; }
+
+        /// <summary>
         /// A flag indicating whether the total number of data objects is required.
         /// </summary>
         public bool RequireTotalCount { get; set; }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -10,7 +10,7 @@ namespace DevExtreme.AspNet.Data {
     /// </summary>
     public class DataSourceLoadOptionsBase {
         /// <summary>
-        /// TODO
+        /// A global default value for the <see cref="StringToLower" /> property
         /// </summary>
         public static bool? StringToLowerDefault { get; set; }
 

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -9,7 +9,6 @@ namespace DevExtreme.AspNet.Data {
     /// Provides static methods for loading data from collections that implement the IEnumerable&lt;T&gt; or IQueryable&lt;T&gt; interface.
     /// </summary>
     public class DataSourceLoader {
-        public static bool? StringToLowerDefault { get; set; }
 
         /// <summary>
         /// Loads data from a collection that implements the IEnumerable&lt;T&gt; interface.

--- a/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoader.cs
@@ -9,6 +9,7 @@ namespace DevExtreme.AspNet.Data {
     /// Provides static methods for loading data from collections that implement the IEnumerable&lt;T&gt; or IQueryable&lt;T&gt; interface.
     /// </summary>
     public class DataSourceLoader {
+        public static bool? StringToLowerDefault { get; set; }
 
         /// <summary>
         /// Loads data from a collection that implements the IEnumerable&lt;T&gt; interface.


### PR DESCRIPTION
This is a reaction to https://devexpress.com/issue=T701611

Inspired by `DevExpress.Data.Helpers.ServerModeCore.DefaultForceCaseInsensitiveForAnySource` from https://devexpress.com/issue=T383460