### PR TITLE
Fix remote AVG over Double / Float

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupingTests.cs
@@ -352,6 +352,18 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Null(result.Totals[0]);
         }
 
+        [Fact]
+        public void Issue324() {
+            var loadResult = DataSourceLoader.Load(new float?[] { 1, 3 }, new SampleLoadOptions {
+                RemoteGrouping = true,
+                TotalSummary = new[] {
+                    new SummaryInfo { Selector = "this", SummaryType = "avg" }
+                }
+            });
+
+            Assert.Equal(2d, loadResult.summary[0]);
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs
+++ b/net/DevExtreme.AspNet.Data/RemoteGrouping/RemoteAvgAggregator.cs
@@ -7,7 +7,7 @@ namespace DevExtreme.AspNet.Data.Aggregation {
 
     class RemoteAvgAggregator<T> : Aggregator<T> {
         Aggregator<T> _countAggregator;
-        Aggregator<T> _valueAggregator;
+        SumAggregator<T> _valueAggregator;
 
         public RemoteAvgAggregator(IAccessor<T> accessor)
             : base(accessor) {
@@ -21,11 +21,13 @@ namespace DevExtreme.AspNet.Data.Aggregation {
         }
 
         public override object Finish() {
-            var count = (decimal?)_countAggregator.Finish();
+            var count = Convert.ToInt32(_countAggregator.Finish());
             if(count == 0)
                 return null;
 
-            return (decimal?)_valueAggregator.Finish() / count;
+            var valueAccumulator = _valueAggregator.GetAccumulator();
+            valueAccumulator.Divide(count);
+            return valueAccumulator.GetValue();
         }
     }
 


### PR DESCRIPTION
Resolves #324 

New code is based on `AvgAggregator.Finish()`: 
https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/67d806aa52f2f20f66605ea0502b1ff8cdf35bbc/net/DevExtreme.AspNet.Data/Aggregation/AvgAggregator.cs#L25-L33