### PR TITLE
ExpressionCompiler: ensure ReflectedType and DeclaringType match

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.EFCore2/Bug326.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EFCore2/Bug326.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests.EFCore2 {
+    public class Bug326 {
+
+        public abstract class EntityBase {
+            public int ID { get; set; }
+        }
+
+        [Table(nameof(Bug326) + "_" + nameof(Entity))]
+        public class Entity : EntityBase {
+            public string Prop { get; set; }
+        }
+
+        public class DTO : EntityBase {
+            public string Prop { get; set; }
+        }
+
+        [Fact]
+        public void Scenario() {
+            TestDbContext.Exec(context => {
+                var dtoQuery = context.Set<Entity>().Select(i => new DTO { ID = i.ID, Prop = i.Prop });
+
+                Assert.Null(Record.Exception(delegate {
+                    var loadResult = DataSourceLoader.Load(dtoQuery, new SampleLoadOptions {
+                        Take = 1
+                    });
+
+                    loadResult.data.Cast<object>().ToArray();
+                }));
+            });
+        }
+
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data.Tests.EFCore2/TestDbContext.cs
+++ b/net/DevExtreme.AspNet.Data.Tests.EFCore2/TestDbContext.cs
@@ -17,6 +17,7 @@ namespace DevExtreme.AspNet.Data.Tests.EFCore2 {
             modelBuilder.Entity<RemoteGrouping.DataItem>();
             modelBuilder.Entity<RemoteGroupingStress.DataItem>();
             modelBuilder.Entity<Summary.DataItem>();
+            modelBuilder.Entity<Bug326.Entity>();
         }
 
         public static void Exec(Action<TestDbContext> action) {

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -46,7 +46,7 @@ namespace DevExtreme.AspNet.Data {
                 else if(DynamicBindingHelper.ShouldUseDynamicBinding(currentTarget.Type))
                     currentTarget = DynamicBindingHelper.CompileGetMember(currentTarget, clientExprItem);
                 else
-                    currentTarget = Expression.PropertyOrField(currentTarget, clientExprItem);
+                    currentTarget = FixReflectedType(Expression.PropertyOrField(currentTarget, clientExprItem));
 
                 progression.Add(currentTarget);
             }
@@ -113,6 +113,22 @@ namespace DevExtreme.AspNet.Data {
                 "Item",
                 Expression.Constant(member)
             );
+        }
+
+        static MemberExpression FixReflectedType(MemberExpression expr) {
+            var member = expr.Member;
+            var declaringType = member.DeclaringType;
+
+            if(member.ReflectedType != declaringType) {
+                switch(member.MemberType) {
+                    case MemberTypes.Property:
+                        return Expression.Property(expr.Expression, declaringType, member.Name);
+                    case MemberTypes.Field:
+                        return Expression.Field(expr.Expression, declaringType, member.Name);
+                }
+            }
+
+            return expr;
         }
     }
 


### PR DESCRIPTION
Workaround for #326 

More info:
- https://github.com/aspnet/EntityFrameworkCore/issues/12230#issuecomment-398727647
- https://stackoverflow.com/a/23106828

This is how the difference looks in debugger:

![debug](https://user-images.githubusercontent.com/4426185/51035321-b538a700-15ba-11e9-9145-506e9b8f96de.png)
