### PR TITLE
Compatibility with System.Linq.Dynamic.Core dynamic classes

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests.NET4/DevExtreme.AspNet.Data.Tests.NET4.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests.NET4/DevExtreme.AspNet.Data.Tests.NET4.csproj
@@ -55,6 +55,9 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Linq.Dynamic.Core, Version=1.0.10.0, Culture=neutral, PublicKeyToken=0f07ec44de6ac832, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.Dynamic.Core.1.0.10\lib\net46\System.Linq.Dynamic.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>

--- a/net/DevExtreme.AspNet.Data.Tests.NET4/packages.config
+++ b/net/DevExtreme.AspNet.Data.Tests.NET4/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
+  <package id="System.Linq.Dynamic.Core" version="1.0.10" targetFramework="net461" />
   <package id="xunit" version="2.3.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.analyzers" version="0.8.0" targetFramework="net461" />

--- a/net/DevExtreme.AspNet.Data.Tests/DevExtreme.AspNet.Data.Tests.csproj
+++ b/net/DevExtreme.AspNet.Data.Tests/DevExtreme.AspNet.Data.Tests.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\DevExtreme.AspNet.Data\DevExtreme.AspNet.Data.csproj" />
     <ProjectReference Include="..\DevExtreme.AspNet.Data.Tests.Common\DevExtreme.AspNet.Data.Tests.Common.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.10" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -235,6 +235,16 @@ namespace DevExtreme.AspNet.Data.Tests {
                 "a"
             );
         }
+
+        [Fact]
+        public void T714342() {
+            var data = System.Linq.Dynamic.Core.DynamicQueryableExtensions.Select(
+                new[] { new { CategoryID = 1 } }.AsQueryable(),
+                "new { CategoryID }"
+            );
+
+            Assert.False(DynamicBindingHelper.ShouldUseDynamicBinding(data.ElementType));
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DynamicBindingHelper.cs
+++ b/net/DevExtreme.AspNet.Data/DynamicBindingHelper.cs
@@ -14,7 +14,18 @@ namespace DevExtreme.AspNet.Data {
         static IEnumerable<CSharpArgumentInfo> EMPTY_ARGUMENT_INFO;
 
         public static bool ShouldUseDynamicBinding(Type type) {
-            return type == typeof(object) || typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type);
+            if(type == typeof(object))
+                return true;
+
+            if(typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type)) {
+                var name = type.AssemblyQualifiedName;
+                if(name.Contains("f__AnonymousType") && name.Contains("System.Linq.Dynamic.Core.DynamicClasses"))
+                    return false;
+
+                return true;
+            }
+
+            return false;
         }
 
         public static Expression CompileGetMember(Expression target, string clientExpr) {


### PR DESCRIPTION
Resolves https://devexpress.com/issue=T714342

[System.Linq.Dynamic.Core](https://www.nuget.org/packages/System.Linq.Dynamic.Core) builds runtime [anonymous types](https://github.com/StefH/System.Linq.Dynamic.Core/blob/8e276f9936caa6801efb0c00937b071524168174/src/System.Linq.Dynamic.Core/DynamicClassFactory.cs#L123) that extend [DynamicObject](https://github.com/StefH/System.Linq.Dynamic.Core/blob/8e276f9936caa6801efb0c00937b071524168174/src/System.Linq.Dynamic.Core/DynamicClass.cs#L19). 

This PR adds an exception for these types so that they are treated as ordinary anonymous types.