### PR TITLE
Fix TypeScript declarations for 18.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,11 @@ test_script:
   - npm run eslint
 
   - npm i --no-save "devextreme@~18.1.0"
+  - npm run dts
   - npm run karma
 
   - npm i --no-save "devextreme@>=18.2.0"
+  - npm run dts
   - npm run karma
   - npm run karma-bundled
   - npm run karma-bundled-nojquery

--- a/js/dx.aspnet.data.d.ts
+++ b/js/dx.aspnet.data.d.ts
@@ -1,5 +1,4 @@
 import CustomStore from "devextreme/data/custom_store";
-import { LoadOptions } from "devextreme/data/load_options";
 
 interface Options {
     key?: string|Array<string>,
@@ -24,7 +23,7 @@ interface Options {
     onBeforeSend?: (operation: string, ajaxSettings: JQueryAjaxSettings) => void,
     onAjaxError?: (e: { xhr: JQueryXHR, error: string | Error }) => void
 
-    onLoading?: (loadOptions: LoadOptions) => void;
+    onLoading?: (loadOptions: any) => void;
     onLoaded?: (result: Array<any>) => void;
 
     onInserting?: (values: any) => void;


### PR DESCRIPTION
- Recover d.ts compilation check that has been lost in 1354c6a
- Replace `LoadOptions` with `any` for compatibility with 18.1