### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ test_script:
     -output:coverage_netcore3.xml
 
   - >-
-    OpenCover\tools\OpenCover.Console -returntargetcode -register:user
+    OpenCover\tools\OpenCover.Console -returntargetcode -register:Path64
     -target:%xunit20%\xunit.console.exe
     -targetargs:"
     net\DevExtreme.AspNet.Data.Tests.NET4\bin\Debug\DevExtreme.AspNet.Data.Tests.dll


### PR DESCRIPTION
This will resolve ["No results"](https://ci.appveyor.com/project/dxrobot/devextreme-aspnet-data/builds/26508519#L347) for .NET Framework tests.

First appearance: https://ci.appveyor.com/project/dxrobot/devextreme-aspnet-data/builds/26479555

Possibly after https://www.appveyor.com/updates/2019/08/01/