### PR TITLE
Support DBNull in DynamicCompare

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -245,6 +245,26 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             Assert.False(DynamicBindingHelper.ShouldUseDynamicBinding(data.ElementType));
         }
+
+        [Fact]
+        public void DBNull() {
+            dynamic item1 = new ExpandoObject();
+            dynamic item2 = new ExpandoObject();
+            item1.p = 123;
+            item2.p = System.DBNull.Value;
+
+            var source = new[] { item1, item2 };
+
+            Assert.Equal(1, DataSourceLoader.Load(source, new SampleLoadOptions {
+                Filter = new object[] { "p", 123 },
+                RequireTotalCount = true
+            }).totalCount);
+
+            Assert.Equal(1, DataSourceLoader.Load(source, new SampleLoadOptions {
+                Filter = new object[] { "p", null },
+                RequireTotalCount = true
+            }).totalCount);
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Utils.cs
+++ b/net/DevExtreme.AspNet.Data/Utils.cs
@@ -91,6 +91,9 @@ namespace DevExtreme.AspNet.Data {
         }
 
         public static int DynamicCompare(object selectorResult, object clientValue) {
+            if(selectorResult is DBNull)
+                selectorResult = null;
+
             if(selectorResult != null)
                 clientValue = ConvertClientValue(clientValue, selectorResult.GetType());
             else


### PR DESCRIPTION
Use case reported by a customer in T814494: `DataRow` transformed into `ExpandoObject`.