### PR TITLE
DataSourceLoader should compare Select and PreSelect intersect with ignore case.

### DIFF
--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -246,7 +246,7 @@ namespace DevExtreme.AspNet.Data {
                     var hasPreSelect = !IsEmpty(_options.PreSelect);
 
                     if(hasPreSelect && hasSelect)
-                        return Enumerable.Intersect(_options.PreSelect, _options.Select).ToArray();
+                        return Enumerable.Intersect(_options.PreSelect, _options.Select, StringComparer.CurrentCultureIgnoreCase).ToArray();
 
                     if(hasPreSelect)
                         return _options.PreSelect;


### PR DESCRIPTION
Fixed Select and PreSelect intersect to support ignore case. This is required because of the coding standard. The client side use pascalCase and server use CamelCase.