### PR TITLE
Minimize the use of IQueryable generic parameter

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/Compat.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/Compat.cs
@@ -17,13 +17,13 @@ namespace DevExtreme.AspNet.Data.Tests {
             return text.Append(")").ToString();
         }
 
-        public static DataSourceExpressionBuilder<T> CreateDataSourceExpressionBuilder<T>(DataSourceLoadOptionsBase options) {
+        public static DataSourceExpressionBuilder CreateDataSourceExpressionBuilder<T>(DataSourceLoadOptionsBase options) {
             var source = new EnumerableQuery<T>(Expression.Parameter(typeof(IQueryable<T>), "data"));
             return CreateDataSourceExpressionBuilder(source, options);
         }
 
-        public static DataSourceExpressionBuilder<T> CreateDataSourceExpressionBuilder<T>(IQueryable<T> source, DataSourceLoadOptionsBase options) {
-            return new DataSourceExpressionBuilder<T>(
+        public static DataSourceExpressionBuilder CreateDataSourceExpressionBuilder<T>(IQueryable<T> source, DataSourceLoadOptionsBase options) {
+            return new DataSourceExpressionBuilder(
                 source.Expression,
                 new DataSourceLoadContext(
                     options,

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -215,7 +215,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void NoToStringForNumbers() {
-            var compiler = new FilterExpressionCompiler<dynamic>(false);
+            var compiler = new FilterExpressionCompiler(typeof(object), false);
 
             void Case(IList clientFilter, string expectedExpr, object trueTestValue) {
                 var expr = compiler.Compile(clientFilter);

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -270,6 +270,23 @@ namespace DevExtreme.AspNet.Data.Tests {
                 RequireTotalCount = true
             }).totalCount);
         }
+
+        [Fact]
+        public void Issue413() {
+            // https://github.com/DevExpress/DevExtreme.AspNet.Data/issues/413#issuecomment-580766581
+
+            IQueryable<object> projection = new[] { new { A = 1 } }
+                .AsQueryable()
+                .Select(i => new { i.A });
+
+            var loadResult = DataSourceLoader.Load(projection, new SampleLoadOptions {
+                Filter = new[] { "A", "1" }
+            });
+
+            var error = Record.Exception(() => loadResult.data.Cast<object>().ToArray());
+
+            Assert.Contains("'object' does not contain a definition for 'A'", error.Message);
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicBindingTests.cs
@@ -280,12 +280,11 @@ namespace DevExtreme.AspNet.Data.Tests {
                 .Select(i => new { i.A });
 
             var loadResult = DataSourceLoader.Load(projection, new SampleLoadOptions {
-                Filter = new[] { "A", "1" }
+                Filter = new[] { "A", "1" },
+                RequireTotalCount = true
             });
 
-            var error = Record.Exception(() => loadResult.data.Cast<object>().ToArray());
-
-            Assert.Contains("'object' does not contain a definition for 'A'", error.Message);
+            Assert.Equal(1, loadResult.totalCount);
         }
     }
 

--- a/net/DevExtreme.AspNet.Data.Tests/ExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/ExpressionCompilerTests.cs
@@ -12,7 +12,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         class SampleCompiler : ExpressionCompiler {
 
             public SampleCompiler(bool guardNulls)
-                : base(guardNulls) {
+                : base(null, guardNulls) {
             }
 
         }

--- a/net/DevExtreme.AspNet.Data.Tests/Extensions.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/Extensions.cs
@@ -4,8 +4,8 @@ using System.Linq.Expressions;
 namespace DevExtreme.AspNet.Data.Tests {
 
     static class Extensions {
-        public static Expression BuildLoadExpr<T>(this DataSourceExpressionBuilder<T> builder) => builder.BuildLoadExpr(true);
-        public static Expression BuildLoadGroupsExpr<T>(this DataSourceExpressionBuilder<T> builder) => builder.BuildLoadGroupsExpr(false);
+        public static Expression BuildLoadExpr(this DataSourceExpressionBuilder builder) => builder.BuildLoadExpr(true);
+        public static Expression BuildLoadGroupsExpr(this DataSourceExpressionBuilder builder) => builder.BuildLoadGroupsExpr(false);
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
@@ -19,7 +19,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         LambdaExpression Compile<T>(IList criteria, bool guardNulls = false) {
-            return new FilterExpressionCompiler<T>(guardNulls).Compile(criteria);
+            return new FilterExpressionCompiler(typeof(T), guardNulls).Compile(criteria);
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         [Fact]
         public void IsUnaryWithJsonCriteria() {
             var crit = JsonConvert.DeserializeObject<IList>("[\"!\", []]");
-            var compiler = new FilterExpressionCompiler<object>(false);
+            var compiler = new FilterExpressionCompiler(typeof(object), false);
             Assert.True(compiler.IsUnary(crit));
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTypeConversionTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTypeConversionTests.cs
@@ -10,7 +10,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         const string TEST_GUID = "01234567-0123-0123-0123-012345670000";
 
         void AssertEvaluation<T>(T dataItem, params object[] clientFilter) {
-            var expr = new FilterExpressionCompiler<T>(false).Compile(clientFilter);
+            var expr = new FilterExpressionCompiler(typeof(T), false).Compile(clientFilter);
             Assert.True((bool)expr.Compile().DynamicInvoke(dataItem));
         }
 
@@ -161,7 +161,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void InvalidValueHandling() {
-            var compiler = new FilterExpressionCompiler<Structs>(false);
+            var compiler = new FilterExpressionCompiler(typeof(Structs), false);
 
             Assert.Equal("False", compiler.Compile(new[] { "byte", "-3" }).Body.ToString());
             Assert.Equal("False", compiler.Compile(new[] { "byte", "257" }).Body.ToString());

--- a/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/RemoteGroupExpressionCompilerTests.cs
@@ -24,7 +24,8 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void Compile() {
-            var compiler = new RemoteGroupExpressionCompiler<DataItem>(
+            var compiler = new RemoteGroupExpressionCompiler(
+                typeof(DataItem),
                 new[] {
                     new GroupingInfo { Selector = "G1" },
                     new GroupingInfo { Selector = "G2", Desc = true }
@@ -83,7 +84,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void CompileEmpty() {
-            var expr = new RemoteGroupExpressionCompiler<DataItem>(null, null, null).Compile(CreateTargetParam<DataItem>());
+            var expr = new RemoteGroupExpressionCompiler(typeof(DataItem), null, null, null).Compile(CreateTargetParam<DataItem>());
             Assert.Equal(
                 "data"
                     + ".GroupBy(obj => new AnonType())"
@@ -94,7 +95,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void IgnoreGroupSummaryIfNoGroups() {
-            var compiler = new RemoteGroupExpressionCompiler<DataItem>(null, null, new[] {
+            var compiler = new RemoteGroupExpressionCompiler(typeof(DataItem), null, null, new[] {
                 new SummaryInfo { Selector = "ignore me", SummaryType = "ignore me" }
             });
 
@@ -105,8 +106,8 @@ namespace DevExtreme.AspNet.Data.Tests {
         public void GroupInterval_Numeric() {
 
             string Compile<T>(string selector, bool guardNulls) {
-                var compiler = new RemoteGroupExpressionCompiler<T>(
-                    guardNulls, false, null,
+                var compiler = new RemoteGroupExpressionCompiler(
+                    typeof(T), guardNulls, false, null,
                     new[] {
                         new GroupingInfo { Selector = selector, GroupInterval = "123" }
                     },
@@ -129,8 +130,8 @@ namespace DevExtreme.AspNet.Data.Tests {
         public void GroupInterval_Date() {
 
             string Compile<T>(string selector, bool guardNulls) {
-                var compiler = new RemoteGroupExpressionCompiler<T>(
-                    guardNulls, false, null,
+                var compiler = new RemoteGroupExpressionCompiler(
+                    typeof(T), guardNulls, false, null,
                     new[] {
                         new GroupingInfo { Selector = selector, GroupInterval = "year" },
                         new GroupingInfo { Selector = selector, GroupInterval = "quarter" },
@@ -204,7 +205,8 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         void Bug100Core<T>(params string[] memberNames) {
-            var compiler = new RemoteGroupExpressionCompiler<T>(
+            var compiler = new RemoteGroupExpressionCompiler(
+                typeof(T),
                 memberNames.Select(i => new GroupingInfo { Selector = i }).ToArray(),
                 null,
                 null
@@ -218,7 +220,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void GetSumType_ExpandFalse() {
-            Type GetSumType<T>() => RemoteGroupExpressionCompiler<object>.GetSumType(typeof(T), false);
+            Type GetSumType<T>() => RemoteGroupExpressionCompiler.GetSumType(typeof(T), false);
 
             // Validation: check lambda type in new T[0].Sum(i => i)
 
@@ -241,7 +243,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void GetSumType_ExpandTrue() {
-            Type GetSumType<T>() => RemoteGroupExpressionCompiler<object>.GetSumType(typeof(T), true);
+            Type GetSumType<T>() => RemoteGroupExpressionCompiler.GetSumType(typeof(T), true);
 
             // Don't convert integer types to decimal because SQL decimals have variable precision
             // Except for UInt64 for which there is no better choice

--- a/net/DevExtreme.AspNet.Data.Tests/SelectExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SelectExpressionCompilerTests.cs
@@ -10,7 +10,7 @@ namespace DevExtreme.AspNet.Data.Tests {
     public class SelectExpressionCompilerTests {
 
         Expression Compile<T>(params string[] selectors) {
-            return new SelectExpressionCompiler<T>(false).Compile(
+            return new SelectExpressionCompiler(typeof(T), false).Compile(
                 Expression.Parameter(typeof(IQueryable<T>), "data"),
                 selectors
             );

--- a/net/DevExtreme.AspNet.Data.Tests/SortExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SortExpressionCompilerTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace DevExtreme.AspNet.Data.Tests {
 
     public class SortExpressionCompilerTests {
-        SortExpressionCompiler<DataItem1> _compiler;
+        SortExpressionCompiler _compiler;
         Expression _targetExpr;
 
         class DataItem1 {
@@ -22,7 +22,7 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         public SortExpressionCompilerTests() {
-            _compiler = new SortExpressionCompiler<DataItem1>(false);
+            _compiler = new SortExpressionCompiler(typeof(DataItem1), false);
             _targetExpr = Expression.Parameter(typeof(IQueryable<DataItem1>), "data");
         }
 
@@ -91,7 +91,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             };
 
             var targetExpr = Expression.Parameter(typeof(IQueryable<DataItem2>), "data");
-            var expr = new SortExpressionCompiler<DataItem2>(false).Compile(targetExpr, clientExpr);
+            var expr = new SortExpressionCompiler(typeof(DataItem2), false).Compile(targetExpr, clientExpr);
             Assert.Equal("data.OrderBy(obj => obj.Inner.Prop1)", expr.ToString());
         }
 

--- a/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/StringToLowerTests.cs
@@ -53,7 +53,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void Dynamic() {
-            var compiler = new FilterExpressionCompiler<dynamic>(true, true);
+            var compiler = new FilterExpressionCompiler(typeof(object), true, true);
             var expr = compiler.Compile(new object[] {
                 new[] { "this", "startswith", "1" },
                 "or",
@@ -97,7 +97,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
             Assert.Equal(
                 expectedExpr,
-                new FilterExpressionCompiler<T>(guardNulls, stringToLower)
+                new FilterExpressionCompiler(typeof(T), guardNulls, stringToLower)
                     .Compile(new[] { "this", op, "T" })
                     .Body.ToString()
             );

--- a/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
@@ -13,14 +13,12 @@ namespace DevExtreme.AspNet.Data.Aggregation {
     // https://en.wikipedia.org/wiki/Empty_sum
 
     class SumFix : ExpressionCompiler {
-        Expression _typeParam;
         IReadOnlyList<SummaryInfo> _totalSummary;
         IReadOnlyList<SummaryInfo> _groupSummary;
         IDictionary<string, object> _defaultValues;
 
-        public SumFix(Type type, IReadOnlyList<SummaryInfo> totalSummary, IReadOnlyList<SummaryInfo> groupSummary)
-            : base(false) {
-            _typeParam = Expression.Parameter(type);
+        public SumFix(Type itemType, IReadOnlyList<SummaryInfo> totalSummary, IReadOnlyList<SummaryInfo> groupSummary)
+            : base(itemType, false) {
             _totalSummary = totalSummary;
             _groupSummary = groupSummary;
         }
@@ -54,7 +52,7 @@ namespace DevExtreme.AspNet.Data.Aggregation {
                 _defaultValues = new Dictionary<string, object>();
 
             if(!_defaultValues.ContainsKey(selector)) {
-                var expr = CompileAccessorExpression(_typeParam, selector);
+                var expr = CompileAccessorExpression(CreateItemParam(), selector);
                 var acc = AccumulatorFactory.Create(Utils.StripNullableType(expr.Type));
                 _defaultValues[selector] = acc.GetValue();
             }

--- a/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceExpressionBuilder.cs
@@ -51,7 +51,7 @@ namespace DevExtreme.AspNet.Data {
             if(filterOverride != null || Context.HasFilter) {
                 var filterExpr = filterOverride != null && filterOverride.Count < 1
                     ? Expression.Lambda(Expression.Constant(false), Expression.Parameter(typeof(T)))
-                    : new FilterExpressionCompiler<T>(Context.GuardNulls, Context.UseStringToLower).Compile(filterOverride ?? Context.Filter);
+                    : new FilterExpressionCompiler(Expr.Type.GenericTypeArguments[0], Context.GuardNulls, Context.UseStringToLower).Compile(filterOverride ?? Context.Filter);
 
                 Expr = QueryableCall(nameof(Queryable.Where), Expression.Quote(filterExpr));
             }
@@ -59,7 +59,7 @@ namespace DevExtreme.AspNet.Data {
 
         void AddSort() {
             if(Context.HasAnySort)
-                Expr = new SortExpressionCompiler<T>(Context.GuardNulls).Compile(Expr, Context.GetFullSort());
+                Expr = new SortExpressionCompiler(typeof(T), Context.GuardNulls).Compile(Expr, Context.GetFullSort());
         }
 
         void AddSelect(IReadOnlyList<string> selectOverride = null) {
@@ -76,8 +76,8 @@ namespace DevExtreme.AspNet.Data {
         }
 
         void AddRemoteGrouping(bool suppressGroups, bool suppressTotals) {
-            var compiler = new RemoteGroupExpressionCompiler<T>(
-                Context.GuardNulls, Context.ExpandLinqSumType, Context.CreateAnonTypeNewTweaks(),
+            var compiler = new RemoteGroupExpressionCompiler(
+                typeof(T), Context.GuardNulls, Context.ExpandLinqSumType, Context.CreateAnonTypeNewTweaks(),
                 suppressGroups ? null : Context.Group,
                 suppressTotals ? null : Context.TotalSummary,
                 suppressGroups ? null : Context.GroupSummary
@@ -89,14 +89,14 @@ namespace DevExtreme.AspNet.Data {
             Expr = QueryableCall(nameof(Queryable.Count));
         }
 
-        SelectExpressionCompiler<T> CreateSelectCompiler()
-            => new SelectExpressionCompiler<T>(Context.GuardNulls, Context.CreateAnonTypeNewTweaks());
+        SelectExpressionCompiler CreateSelectCompiler()
+            => new SelectExpressionCompiler(typeof(T), Context.GuardNulls, Context.CreateAnonTypeNewTweaks());
 
         Expression QueryableCall(string methodName)
-            => Expression.Call(typeof(Queryable), methodName, Expr.Type.GetGenericArguments(), Expr);
+            => Expression.Call(typeof(Queryable), methodName, Expr.Type.GenericTypeArguments, Expr);
 
         Expression QueryableCall(string methodName, Expression arg)
-            => Expression.Call(typeof(Queryable), methodName, Expr.Type.GetGenericArguments(), Expr, arg);
+            => Expression.Call(typeof(Queryable), methodName, Expr.Type.GenericTypeArguments, Expr, arg);
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -38,7 +38,7 @@ namespace DevExtreme.AspNet.Data {
 #endif
         }
 
-        DataSourceExpressionBuilder<S> CreateBuilder() => new DataSourceExpressionBuilder<S>(Source.Expression, Context);
+        DataSourceExpressionBuilder CreateBuilder() => new DataSourceExpressionBuilder(Source.Expression, Context);
 
         public async Task<LoadResult> LoadAsync() {
             if(Context.IsCountQuery)

--- a/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 namespace DevExtreme.AspNet.Data {
 
     class DataSourceLoaderImpl<S> {
-        readonly IQueryable<S> Source;
+        readonly IQueryable Source;
         readonly DataSourceLoadContext Context;
         readonly Func<Expression, ExpressionExecutor> CreateExecutor;
 
@@ -25,11 +25,11 @@ namespace DevExtreme.AspNet.Data {
         readonly bool UseEnumerableOnce;
 #endif
 
-        public DataSourceLoaderImpl(IQueryable<S> source, DataSourceLoadOptionsBase options, CancellationToken cancellationToken, bool sync) {
+        public DataSourceLoaderImpl(IQueryable source, DataSourceLoadOptionsBase options, CancellationToken cancellationToken, bool sync) {
             var providerInfo = new QueryProviderInfo(source.Provider);
 
             Source = source;
-            Context = new DataSourceLoadContext(options, providerInfo, typeof(S));
+            Context = new DataSourceLoadContext(options, providerInfo, Source.ElementType);
             CreateExecutor = expr => new ExpressionExecutor(Source.Provider, expr, providerInfo, cancellationToken, sync);
 
 #if DEBUG
@@ -179,7 +179,7 @@ namespace DevExtreme.AspNet.Data {
 
         async Task<RemoteGroupingResult> ExecRemoteGroupingAsync(bool remotePaging, bool suppressGroups, bool suppressTotals) {
             return RemoteGroupTransformer.Run(
-                typeof(S),
+                Source.ElementType,
                 await ExecExprAsync<AnonType>(CreateBuilder().BuildLoadGroupsExpr(remotePaging, suppressGroups, suppressTotals)),
                 !suppressGroups && Context.HasGroups ? Context.Group.Count : 0,
                 !suppressTotals ? Context.TotalSummary : null,

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -10,14 +10,12 @@ using System.Threading.Tasks;
 namespace DevExtreme.AspNet.Data {
 
     abstract class ExpressionCompiler {
-        bool _guardNulls;
+        protected readonly Type ItemType;
+        protected readonly bool GuardNulls;
 
-        public ExpressionCompiler(bool guardNulls) {
-            _guardNulls = guardNulls;
-        }
-
-        protected bool GuardNulls {
-            get { return _guardNulls; }
+        public ExpressionCompiler(Type itemType, bool guardNulls) {
+            ItemType = itemType;
+            GuardNulls = guardNulls;
         }
 
         protected internal Expression CompileAccessorExpression(Expression target, string clientExpr, Action<List<Expression>> customizeProgression = null, bool liftToNullable = false) {
@@ -53,7 +51,7 @@ namespace DevExtreme.AspNet.Data {
 
             customizeProgression?.Invoke(progression);
 
-            if(_guardNulls && progression.Count > 1 || liftToNullable && progression.Count > 2) {
+            if(GuardNulls && progression.Count > 1 || liftToNullable && progression.Count > 2) {
                 var lastIndex = progression.Count - 1;
                 var last = progression[lastIndex];
                 if(Utils.CanAssignNull(target.Type) && !Utils.CanAssignNull(last.Type))
@@ -67,7 +65,7 @@ namespace DevExtreme.AspNet.Data {
             var last = progression.Last();
             var lastType = last.Type;
 
-            if(!_guardNulls)
+            if(!GuardNulls)
                 return last;
 
             Expression allTests = null;
@@ -97,8 +95,8 @@ namespace DevExtreme.AspNet.Data {
             );
         }
 
-        protected ParameterExpression CreateItemParam(Type type) {
-            return Expression.Parameter(type, "obj");
+        protected ParameterExpression CreateItemParam() {
+            return Expression.Parameter(ItemType, "obj");
         }
 
         internal static void ForceToString(List<Expression> progression) {

--- a/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/FilterExpressionCompiler.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace DevExtreme.AspNet.Data {
 
-    class FilterExpressionCompiler<T> : ExpressionCompiler {
+    class FilterExpressionCompiler : ExpressionCompiler {
         const string
             CONTAINS = "contains",
             NOT_CONTAINS = "notcontains",
@@ -19,13 +19,13 @@ namespace DevExtreme.AspNet.Data {
 
         bool _stringToLower;
 
-        public FilterExpressionCompiler(bool guardNulls, bool stringToLower = false)
-            : base(guardNulls) {
+        public FilterExpressionCompiler(Type itemType, bool guardNulls, bool stringToLower = false)
+            : base(itemType, guardNulls) {
             _stringToLower = stringToLower;
         }
 
         public LambdaExpression Compile(IList criteriaJson) {
-            var dataItemExpr = CreateItemParam(typeof(T));
+            var dataItemExpr = CreateItemParam();
             return Expression.Lambda(CompileCore(dataItemExpr, criteriaJson), dataItemExpr);
         }
 

--- a/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
@@ -9,7 +9,7 @@ namespace DevExtreme.AspNet.Data.Helpers {
         IDictionary<string, Func<T, object>> _accessors;
 
         public DefaultAccessor()
-            : base(true) {
+            : base(typeof(T), true) {
         }
 
         public object Read(T obj, string selector) {
@@ -17,7 +17,7 @@ namespace DevExtreme.AspNet.Data.Helpers {
                 _accessors = new Dictionary<string, Func<T, object>>();
 
             if(!_accessors.ContainsKey(selector)) {
-                var param = CreateItemParam(typeof(T));
+                var param = CreateItemParam();
 
                 _accessors[selector] = Expression.Lambda<Func<T, object>>(
                     Expression.Convert(CompileAccessorExpression(param, selector), typeof(Object)),

--- a/net/DevExtreme.AspNet.Data/SelectExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/SelectExpressionCompiler.cs
@@ -8,11 +8,11 @@ using System.Text;
 
 namespace DevExtreme.AspNet.Data {
 
-    class SelectExpressionCompiler<T> : ExpressionCompiler {
+    class SelectExpressionCompiler : ExpressionCompiler {
         AnonTypeNewTweaks _anonTypeNewTweaks;
 
-        public SelectExpressionCompiler(bool guardNulls, AnonTypeNewTweaks anonTypeNewTweaks = null)
-            : base(guardNulls) {
+        public SelectExpressionCompiler(Type itemType, bool guardNulls, AnonTypeNewTweaks anonTypeNewTweaks = null)
+            : base(itemType, guardNulls) {
             _anonTypeNewTweaks = anonTypeNewTweaks;
         }
 
@@ -23,7 +23,7 @@ namespace DevExtreme.AspNet.Data {
             => Compile(target, new[] { clientExpr }, false);
 
         Expression Compile(Expression target, IEnumerable<string> clientExprList, bool useNew) {
-            var itemExpr = CreateItemParam(typeof(T));
+            var itemExpr = CreateItemParam();
 
             var memberExprList = clientExprList
                 .Select(i => CompileAccessorExpression(itemExpr, i, liftToNullable: true))

--- a/net/DevExtreme.AspNet.Data/SortExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/SortExpressionCompiler.cs
@@ -6,14 +6,14 @@ using System.Threading.Tasks;
 
 namespace DevExtreme.AspNet.Data {
 
-    class SortExpressionCompiler<T> : ExpressionCompiler {
+    class SortExpressionCompiler : ExpressionCompiler {
 
-        public SortExpressionCompiler(bool guardNulls)
-            : base(guardNulls) {
+        public SortExpressionCompiler(Type itemType, bool guardNulls)
+            : base(itemType, guardNulls) {
         }
 
         public Expression Compile(Expression target, IEnumerable<SortingInfo> clientExprList) {
-            var dataItemExpr = CreateItemParam(typeof(T));
+            var dataItemExpr = CreateItemParam();
             var first = true;
 
             foreach(var item in clientExprList) {
@@ -23,7 +23,7 @@ namespace DevExtreme.AspNet.Data {
 
                 var accessorExpr = CompileAccessorExpression(dataItemExpr, selector);
 
-                target = Expression.Call(typeof(Queryable), Utils.GetSortMethod(first, item.Desc), new[] { typeof(T), accessorExpr.Type }, target, Expression.Quote(Expression.Lambda(accessorExpr, dataItemExpr)));
+                target = Expression.Call(typeof(Queryable), Utils.GetSortMethod(first, item.Desc), new[] { ItemType, accessorExpr.Type }, target, Expression.Quote(Expression.Lambda(accessorExpr, dataItemExpr)));
                 first = false;
             }
 


### PR DESCRIPTION
Instead of `IQueryable<T>`, we'll use `IQueryable.ElementType`. This will prevent subtle item-type-related issues like the one described in https://github.com/DevExpress/DevExtreme.AspNet.Data/issues/413#issuecomment-580766581.

Non-remote [select](https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/42bb59a3005f230b61040561032c1cb533782dae/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs#L123) and [grouping](https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/42bb59a3005f230b61040561032c1cb533782dae/net/DevExtreme.AspNet.Data/DataSourceLoaderImpl.cs#L126-L136) still depend on the generic parameter, so we cannot completely switch to untyped `IQueryable`.