### PR TITLE
SortByPrimaryKey option

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceExpressionBuilderTests.cs
@@ -87,6 +87,39 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
+        public void SortByPrimaryKey() {
+
+            void Case(Action<DataSourceLoadOptionsBase> initOptions, Action<string> assert) {
+                var source = new[] {
+                    new { ID = 1, Value = "A" }
+                };
+
+                var loadOptions = new SampleLoadOptions {
+                    GuardNulls = false,
+                    PrimaryKey = new[] { "ID" },
+                    SortByPrimaryKey = false
+                };
+
+                initOptions?.Invoke(loadOptions);
+
+                assert(Compat.CreateDataSourceExpressionBuilder(source.AsQueryable(), loadOptions).BuildLoadExpr().ToString());
+            }
+
+            Case(
+                null,
+                expr => Assert.DoesNotContain("OrderBy", expr)
+            );
+
+            Case(
+                options => options.DefaultSort = "Value",
+                expr => {
+                    Assert.Contains(".OrderBy(obj => obj.Value)", expr);
+                    Assert.DoesNotContain("ThenBy", expr);
+                }
+            );
+        }
+
+        [Fact]
         public void GroupingAddedToSorting() {
             var loadOptions = new SampleLoadOptions {
                 Sort = new[] {

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -138,7 +138,7 @@ namespace DevExtreme.AspNet.Data {
         string[] _primaryKey;
         string _defaultSort;
 
-        public bool HasAnySort => HasGroups || HasSort || HasPrimaryKey || HasDefaultSort;
+        public bool HasAnySort => HasGroups || HasSort || ShouldSortByPrimaryKey || HasDefaultSort;
 
         bool HasSort => !IsEmpty(_options.Sort);
 
@@ -159,6 +159,8 @@ namespace DevExtreme.AspNet.Data {
         public bool HasPrimaryKey => !IsEmpty(PrimaryKey);
 
         bool HasDefaultSort => !String.IsNullOrEmpty(DefaultSort);
+
+        bool ShouldSortByPrimaryKey => HasPrimaryKey && _options.SortByPrimaryKey.GetValueOrDefault(true);
 
         public IEnumerable<SortingInfo> GetFullSort() {
             var memo = new HashSet<string>();
@@ -189,7 +191,7 @@ namespace DevExtreme.AspNet.Data {
             if(HasDefaultSort)
                 requiredSort = requiredSort.Concat(new[] { DefaultSort });
 
-            if(HasPrimaryKey)
+            if(ShouldSortByPrimaryKey)
                 requiredSort = requiredSort.Concat(PrimaryKey);
 
             return Utils.AddRequiredSort(result, requiredSort);

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -110,6 +110,8 @@ namespace DevExtreme.AspNet.Data {
         /// </summary>
         public bool? PaginateViaPrimaryKey { get; set; }
 
+        public bool? SortByPrimaryKey { get; set; }
+
         public bool AllowAsyncOverSync { get; set; }
 
 #if DEBUG


### PR DESCRIPTION
An option to prevent unconditional `ThenBy` if `PrimaryKey` is pecified:

https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/3167f39e86d4d7bfd5da35e25eff6605bb8be017/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs#L192-L195

Motivation:
- T631814 
- [T657002](https://devexpress.com/issue=T657002)
- [T686411](https://devexpress.com/issue=T686411)
- [T826066](https://devexpress.com/issue=T826066) (Blazor)
