### PR TITLE
Use GroupBy(obj => const) for MongoDB

### DIFF
--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -44,7 +44,7 @@ namespace DevExtreme.AspNet.Data {
         }
 
         public AnonTypeNewTweaks CreateAnonTypeNewTweaks() => new AnonTypeNewTweaks {
-            AllowEmpty = !_providerInfo.IsL2S,
+            AllowEmpty = !_providerInfo.IsL2S && !_providerInfo.IsMongoDB,
             AllowUnusedMembers = !_providerInfo.IsL2S
         };
 

--- a/net/DevExtreme.AspNet.Data/QueryProviderInfo.cs
+++ b/net/DevExtreme.AspNet.Data/QueryProviderInfo.cs
@@ -10,6 +10,7 @@ namespace DevExtreme.AspNet.Data {
         public readonly bool IsXPO;
         public readonly bool IsNH;
         public readonly bool IsL2S;
+        public readonly bool IsMongoDB;
         public readonly Version Version;
 
         public QueryProviderInfo(IQueryProvider provider) {
@@ -29,6 +30,8 @@ namespace DevExtreme.AspNet.Data {
                     IsNH = true;
                 else if(typeName.StartsWith("System.Data.Linq."))
                     IsL2S = true;
+                else if(typeName.StartsWith("MongoDB.Driver.Linq."))
+                    IsMongoDB = true;
 
                 Version = type.Assembly.GetName().Version;
             }


### PR DESCRIPTION
Resolves #430

`GroupBy(obj => new AnonType())` fails with
```
.NET type DevExtreme.AspNet.Data.Types.AnonType cannot be mapped to a BsonValue.
```

