### PR TITLE
ConvertClientValue - allow trivial conversion

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/UtilsTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/UtilsTests.cs
@@ -72,6 +72,12 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
         }
 
+        [Fact]
+        public void ConvertClientValue_TrivialConversion() {
+            var value = typeof(UtilsTests);
+            Assert.Same(value, Utils.ConvertClientValue(value, value.GetType()));
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Utils.cs
+++ b/net/DevExtreme.AspNet.Data/Utils.cs
@@ -36,6 +36,9 @@ namespace DevExtreme.AspNet.Data {
             if(value == null || type == null)
                 return value;
 
+            if(value.GetType() == type)
+                return value;
+
             type = StripNullableType(type);
 
             if(IsIntegralType(type) && value is String)


### PR DESCRIPTION
- Return early if no conversion is needed
- Allow non-convertible values in filters
