### PR TITLE
Support Custom Compiler in client expressions

### DIFF
--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -43,7 +43,7 @@ namespace DevExtreme.AspNet.Data {
 
                 if(customResult != null)
                     currentTarget = customResult;
-                else if(currentTarget.Type.GetInterfaces().Any(f => f.IsGenericType && f.GetGenericTypeDefinition() == typeof(IDictionary<string, object>)))
+                else if(currentTarget.Type == typeof(ExpandoObject))
                     currentTarget = ReadExpando(currentTarget, clientExprItem);
                 else if(DynamicBindingHelper.ShouldUseDynamicBinding(currentTarget.Type))
                     currentTarget = DynamicBindingHelper.CompileGetMember(currentTarget, clientExprItem);

--- a/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
+++ b/net/DevExtreme.AspNet.Data/ExpressionCompiler.cs
@@ -39,7 +39,11 @@ namespace DevExtreme.AspNet.Data {
                     i--;
                 }
 
-                if(currentTarget.Type == typeof(ExpandoObject))
+                customResult = CustomAccessorCompilers.TryCompile(currentTarget, clientExprItem);
+
+                if(customResult != null)
+                    currentTarget = customResult;
+                else if(currentTarget.Type.GetInterfaces().Any(f => f.IsGenericType && f.GetGenericTypeDefinition() == typeof(IDictionary<string, object>)))
                     currentTarget = ReadExpando(currentTarget, clientExprItem);
                 else if(DynamicBindingHelper.ShouldUseDynamicBinding(currentTarget.Type))
                     currentTarget = DynamicBindingHelper.CompileGetMember(currentTarget, clientExprItem);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35311793/97714485-82c6a980-1ac1-11eb-9605-cebb99ff8f90.png)
The use case for this is pretty simple. I am using the MongoDB Driver Library. 

My type is a dictionary that has Properties which lookup the values in the dictionary. 

This works fine with simple queries but in the DxDataGrid you get something like "OrderedAt.year" as member in the custom compiler. For "year" I want to use the default logic from the library. For the accessor "OrderedAt" I want to use the Property accessor. 