### PR TITLE
Don't calculate the 'LoadResult.data' field value if Take < 0 

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoaderTests.cs
@@ -476,6 +476,37 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Load_NegativeTake(bool remoteGrouping, bool group) {
+            var loadOptions = new SampleLoadOptions {
+                Filter = new[] { "this", "<", "100" },
+                RemoteGrouping = remoteGrouping,
+                Take = -1,
+                TotalSummary = new[] {
+                    new SummaryInfo { Selector = "this", SummaryType = "sum" }
+                }
+            };
+
+            if(group) {
+                loadOptions.Group = new[] {
+                    new GroupingInfo { Selector = "any", IsExpanded = !remoteGrouping }
+                };
+                loadOptions.GroupSummary = new[] {
+                    new SummaryInfo { Selector = "any", SummaryType = "any" }
+                };
+            }
+
+            var loadResult = DataSourceLoader.Load(new[] { 1, 1, 2, 2, 100 }, loadOptions);
+            Assert.Null(loadResult.data);
+            Assert.Equal(6m, loadResult.summary[0]);
+
+            Assert.Single(loadOptions.ExpressionLog);
+        }
+
+        [Theory]
         [InlineData(false, true)]
         [InlineData(false, false)]
         [InlineData(true, false)]

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadContext.cs
@@ -88,7 +88,7 @@ namespace DevExtreme.AspNet.Data {
 
         public IReadOnlyList<GroupingInfo> Group => _options.Group;
 
-        public bool HasGroups => !IsEmpty(Group);
+        public bool HasGroups => Take > -1 && !IsEmpty(Group);
 
         public bool ShouldEmptyGroups {
             get {
@@ -259,6 +259,8 @@ namespace DevExtreme.AspNet.Data {
                     || _providerInfo.IsXPO;
             }
         }
+
+        public bool IsRemoteTotalSummary => UseRemoteGrouping && !SummaryIsTotalCountOnly && HasSummary && !HasGroups;
     }
 
     // Select


### PR DESCRIPTION
Will allow to load aggregates only