### PR TITLE
Use codecov-action to upload coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - run: pip install codecov
     - run: node build/make-nojquery
 
     - run: npm i --omit=peer
@@ -56,7 +55,9 @@ jobs:
     - run: npm run karma-bundled-nojquery
     - run: npm run karma-bundled-nojquery-cjs
 
-    - run: codecov -X gcov -f js-test/coverage/lcov.info
+    - uses: codecov/codecov-action@v3
+      with:
+        files: js-test/coverage/lcov.info
 
   test-dotnet:
     runs-on: windows-latest
@@ -64,14 +65,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - run: pip install codecov
     - run: nuget install -Verbosity quiet -ExcludeVersion -OutputDirectory . -Version 2022.2.3 JetBrains.dotCover.CommandLineTools
 
     - uses: ./.github/actions/dotnet-test-build
 
     - run: JetBrains.dotCover.CommandLineTools\tools\dotCover cover --ReturnTargetExitCode --ReportType=DetailedXML --Filters="+:module=DevExtreme.AspNet.Data" --Output=coverage_dotnet.xml --TargetExecutable=net\dotnet-test-all.cmd
 
-    - run: codecov -X gcov -f coverage_dotnet.xml
+    - uses: codecov/codecov-action@v3
+      with:
+        files: coverage_dotnet.xml
 
   release-packages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use codecov-action to upload coverage reports instead of deprecated codecov uploader.