### PR TITLE
Recover dotnet 3.1 for release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-quality: ga
-        dotnet-version: 6.0
+        dotnet-version: |
+          3.1
+          6.0
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
The dotnet-version v3.1 setup is required for the CI / release step that relies on the https://github.com/appveyor/secure-file, which is built under netcoreapp3.1.