### PR TITLE
Extract unwrapping DataSourceLoadOptionsBase IList Filter to Converter

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/CustomFilterCompilersTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/CustomFilterCompilersTests.cs
@@ -11,6 +11,9 @@ using Xunit;
 namespace DevExtreme.AspNet.Data.Tests {
 
     public class CustomFilterCompilersTests {
+        static readonly JsonSerializerOptions TESTS_DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
+            Converters = { new ListConverter() }
+        };
 
         [Fact]
         public void OneToManyContains() {
@@ -35,8 +38,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 var source = new[] { new Category(), new Category() };
                 source[0].Products.Add(new Product { Name = "Chai" });
 
-                var deserializedList = JsonSerializer.Deserialize<IList>(@"[ ""Products"", ""Contains"", ""ch"" ]");
-                var filter = Compatibility.UnwrapList(deserializedList);
+                var filter = JsonSerializer.Deserialize<IList>(@"[ ""Products"", ""Contains"", ""ch"" ]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
 
                 var loadOptions = new SampleLoadOptions {
                     Filter = filter,

--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
@@ -9,6 +9,9 @@ using Xunit;
 namespace DevExtreme.AspNet.Data.Tests {
 
     public class FilterExpressionCompilerTests {
+        static readonly JsonSerializerOptions TESTS_DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
+            Converters = { new ListConverter() }
+        };
 
         class DataItem1 {
             public int IntProp { get; set; }
@@ -143,8 +146,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void IsUnaryWithJsonCriteria() {
-            var deserializedList = JsonSerializer.Deserialize<IList>("[\"!\", []]");
-            var crit = Compatibility.UnwrapList(deserializedList);
+            var crit = JsonSerializer.Deserialize<IList>("[\"!\", []]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
             var compiler = new FilterExpressionCompiler(typeof(object), false);
             Assert.True(compiler.IsUnary(crit));
         }
@@ -241,8 +243,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void JsonObjects() {
-            var deserializedList = JsonSerializer.Deserialize<IList>(@"[ [ ""StringProp"", ""abc"" ], [ ""NullableProp"", null ] ]");
-            var crit = Compatibility.UnwrapList(deserializedList);
+            var crit = JsonSerializer.Deserialize<IList>(@"[ [ ""StringProp"", ""abc"" ], [ ""NullableProp"", null ] ]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
             var expr = Compile<DataItem1>(crit);
             Assert.Equal(@"((obj.StringProp == ""abc"") AndAlso (obj.NullableProp == null))", expr.Body.ToString());
         }

--- a/net/DevExtreme.AspNet.Data/Compatibility.cs
+++ b/net/DevExtreme.AspNet.Data/Compatibility.cs
@@ -61,10 +61,16 @@ namespace DevExtreme.AspNet.Data {
             throw new NotImplementedException();
         }
 
-        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) {
-            throw new NotImplementedException();
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) => throw new NotImplementedException();
+    }
+
+    class ListConverter : JsonConverter<IList> {
+        public override IList Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+            var deserializedList = JsonSerializer.Deserialize<IList>(ref reader);
+            return Compatibility.UnwrapList(deserializedList);
         }
 
+        public override void Write(Utf8JsonWriter writer, IList value, JsonSerializerOptions options) => throw new NotImplementedException();
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
+++ b/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
+using System.Text.Json.Serialization;
 
 namespace DevExtreme.AspNet.Data {
 
@@ -56,6 +56,7 @@ namespace DevExtreme.AspNet.Data {
         /// <summary>
         /// A filter expression.
         /// </summary>
+        [JsonConverter(typeof(ListConverter))]
         public IList Filter { get; set; }
 
         /// <summary>

--- a/net/DevExtreme.AspNet.Data/Helpers/DataSourceLoadOptionsParser.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DataSourceLoadOptionsParser.cs
@@ -8,7 +8,9 @@ namespace DevExtreme.AspNet.Data.Helpers {
     /// A parser for the data processing settings.
     /// </summary>
     public static class DataSourceLoadOptionsParser {
-        static readonly JsonSerializerOptions DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        static readonly JsonSerializerOptions DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
+            Converters = { new ListConverter() }
+        };
 
         public const string
             KEY_REQUIRE_TOTAL_COUNT = "requireTotalCount",
@@ -62,10 +64,8 @@ namespace DevExtreme.AspNet.Data.Helpers {
             if(!String.IsNullOrEmpty(group))
                 loadOptions.Group = JsonSerializer.Deserialize<GroupingInfo[]>(group, DEFAULT_SERIALIZER_OPTIONS);
 
-            if(!String.IsNullOrEmpty(filter)) {
-                var deserializedList = JsonSerializer.Deserialize<IList>(filter);
-                loadOptions.Filter = Compatibility.UnwrapList(deserializedList);
-            }
+            if(!String.IsNullOrEmpty(filter))
+                loadOptions.Filter = JsonSerializer.Deserialize<IList>(filter, DEFAULT_SERIALIZER_OPTIONS);
 
             if(!String.IsNullOrEmpty(totalSummary))
                 loadOptions.TotalSummary = JsonSerializer.Deserialize<SummaryInfo[]>(totalSummary, DEFAULT_SERIALIZER_OPTIONS);


### PR DESCRIPTION
Follow-up on #605
- DataSourceLoadOptionsParser -> Filter: uses a new converter through options (could de-serialize client settings through a custom model binder);
- DataSourceLoadOptionsBase -> Filter: uses the new converter through an attribute (could de-serialize client settings directly - without a custom model binder).