### PR TITLE
Remove Microsoft.CSharp / conditional references for net6

### DIFF
--- a/net/DevExtreme.AspNet.Data/DevExtreme.AspNet.Data.csproj
+++ b/net/DevExtreme.AspNet.Data/DevExtreme.AspNet.Data.csproj
@@ -25,10 +25,6 @@
     <PackageReference Include="System.Text.Json" Version="6.0.9" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
     <None Update="Types\AnonType.Generated.tt">


### PR DESCRIPTION
'net6.0' does not require the target-specific conditional references