### PR TITLE
Prevent DataSourceLoadOptionsParser from System.InvalidOperationException on parsing binary filter with value null

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoadOptionsParserTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoadOptionsParserTests.cs
@@ -60,6 +60,19 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
+        public void MustParseNull() {
+            var opts = new SampleLoadOptions();
+
+            DataSourceLoadOptionsParser.Parse(opts, key => {
+                if(key == DataSourceLoadOptionsParser.KEY_FILTER)
+                    return @"[ ""fieldName"", ""="", null ]";
+                return null;
+            });
+
+            Assert.Equal(new[] { "fieldName", "=", null }, opts.Filter.Cast<string>());
+        }
+
+        [Fact]
         public void MustParseNumericAsString() {
             var opts = new SampleLoadOptions();
 

--- a/net/DevExtreme.AspNet.Data.Tests/DeserializeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DeserializeTests.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Text.Json;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class DeserializeTests {
+        static readonly JsonSerializerOptions TESTS_DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
+            Converters = { new ListConverter() }
+        };
+
+        [Theory]
+        [InlineData(@"[""fieldName"",""="",null]")]
+        [InlineData(@"[[""fieldName1"",""="",""""],""and"",[""fieldName2"",""="",null]]")]
+        public void FilterOperandValueCanBeNull(string rawJsonCriteria) {
+            var deserializedList = JsonSerializer.Deserialize<IList>(rawJsonCriteria, TESTS_DEFAULT_SERIALIZER_OPTIONS);
+            Assert.Equal(3, deserializedList.Count);
+        }
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data.Tests/DeserializeTestsEx.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DeserializeTestsEx.cs
@@ -1,0 +1,19 @@
+﻿#if NEWTONSOFT_TESTS
+using System.Collections;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class DeserializeTestsEx {
+        [Theory]
+        [InlineData(@"[""fieldName"",""="",null]")]
+        [InlineData(@"[[""fieldName1"",""="",""""],""and"",[""fieldName2"",""="",null]]")]
+        public void FilterOperandValueCanBeNull(string rawJsonCriteria) {
+            var deserializedList = JsonConvert.DeserializeObject<IList>(rawJsonCriteria);
+            Assert.Equal(3, deserializedList.Count);
+        }
+    }
+
+}
+#endif

--- a/net/DevExtreme.AspNet.Data/Compatibility.cs
+++ b/net/DevExtreme.AspNet.Data/Compatibility.cs
@@ -18,6 +18,9 @@ namespace DevExtreme.AspNet.Data {
         }
 
         static object UnwrapJsonElement(object deserializeObject) {
+            if(deserializeObject == null)
+                return null;
+
             if(!(deserializeObject is JsonElement jsonElement))
                 throw new InvalidOperationException();
 


### PR DESCRIPTION
Fixes https://devexpress.com/issue=T1234087

```
DevExtreme.AspNet.Data.dll!DevExtreme.AspNet.Data.Compatibility.UnwrapJsonElement(object deserializeObject) Line 25	C#
DevExtreme.AspNet.Data.dll!DevExtreme.AspNet.Data.Compatibility.UnwrapList(System.Collections.IList deserializedList) Line 16	C#
DevExtreme.AspNet.Data.dll!DevExtreme.AspNet.Data.ListConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) Line 73	C#
System.Text.Json.dll!System.Text.Json.Serialization.JsonConverter<System.Collections.IList>.TryRead(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options, ref System.Text.Json.ReadStack state, out System.Collections.IList value)	Unknown
System.Text.Json.dll!System.Text.Json.Serialization.JsonConverter<System.Collections.IList>.ReadCore(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options, ref System.Text.Json.ReadStack state)	Unknown
System.Text.Json.dll!System.Text.Json.JsonSerializer.ReadFromSpan<System.Collections.IList>(System.ReadOnlySpan<byte> utf8Json, System.Text.Json.Serialization.Metadata.JsonTypeInfo jsonTypeInfo, int? actualByteCount)	Unknown
System.Text.Json.dll!System.Text.Json.JsonSerializer.ReadFromSpan<System.Collections.IList>(System.ReadOnlySpan<char> json, System.Text.Json.Serialization.Metadata.JsonTypeInfo jsonTypeInfo)	Unknown
System.Text.Json.dll!System.Text.Json.JsonSerializer.Deserialize<System.Collections.IList>(string json, System.Text.Json.JsonSerializerOptions options)	Unknown
DevExtreme.AspNet.Data.dll!DevExtreme.AspNet.Data.Helpers.DataSourceLoadOptionsParser.Parse(DevExtreme.AspNet.Data.DataSourceLoadOptionsBase loadOptions, System.Func<string, string> valueSource) Line 68	C#

```