### PR TITLE
Move Sample app connection string to configuration file

### DIFF
--- a/net/Sample/Program.cs
+++ b/net/Sample/Program.cs
@@ -20,7 +20,7 @@ namespace Sample {
                 .AddEntityFrameworkSqlServer()
                 .AddDbContext<NorthwindContext>(options => options
                     //.UseSqlServer("Server=.\\SQLEXPRESS; Database=Northwind; Trusted_Connection=True")
-                    .UseSqlServer("Data Source=(localdb)\\MSSQLLocalDB; Database=Northwind; Integrated Security=True; MultipleActiveResultSets=True; App=EntityFramework")
+                    .UseSqlServer(builder.Configuration.GetConnectionString("NorthwindConnectionString"))
                 );
 
             var app = builder.Build();

--- a/net/Sample/appsettings.json
+++ b/net/Sample/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "ConnectionStrings": {
+    "NorthwindConnectionString": "Data Source=(localdb)\\MSSQLLocalDB; Database=Northwind; Integrated Security=True; MultipleActiveResultSets=True; App=EntityFramework",
+    "NorthwindConnectionStringIis": "Data Source=.; Database=Northwind; User Id=; Password=; MultipleActiveResultSets=True; App=EntityFramework; TrustServerCertificate=True"
+  }
+}


### PR DESCRIPTION
Use known appsettings.json [configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/) file.

For Windows on ARM:
- Run `sqllocaldb i MSSQLLocalDB`
- Use `Instance pipe name` as `DataSource | Server` name

See https://github.com/dotnet/SqlClient/issues/1441 for more info.