### PR TITLE
Prevent DataSourceLoadOptionsParser from System.InvalidOperationException on parsing binary filter with value json object

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DataSourceLoadOptionsParserTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DataSourceLoadOptionsParserTests.cs
@@ -73,6 +73,20 @@ namespace DevExtreme.AspNet.Data.Tests {
         }
 
         [Fact]
+        public void MustParseObject() {
+            var opts = new SampleLoadOptions();
+
+            DataSourceLoadOptionsParser.Parse(opts, key => {
+                if(key == DataSourceLoadOptionsParser.KEY_FILTER)
+                    return @"[ ""fieldName1"", ""="", {""Value"":0} ]";
+                return null;
+            });
+
+            Assert.Equal(3, opts.Filter.Count);
+            Assert.Equal("{\"Value\":0}", opts.Filter[2].ToString());
+        }
+
+        [Fact]
         public void MustParseNumericAsString() {
             var opts = new SampleLoadOptions();
 

--- a/net/DevExtreme.AspNet.Data.Tests/DeserializeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DeserializeTests.cs
@@ -16,6 +16,13 @@ namespace DevExtreme.AspNet.Data.Tests {
             var deserializedList = JsonSerializer.Deserialize<IList>(rawJsonCriteria, TESTS_DEFAULT_SERIALIZER_OPTIONS);
             Assert.Equal(3, deserializedList.Count);
         }
+
+        [Fact]
+        public void FilterOperandValueCanBeObject() {
+            var deserializedList = JsonSerializer.Deserialize<IList>(@"[""fieldName1"",""="",{""Value"":0}]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
+            Assert.Equal(3, deserializedList.Count);
+            Assert.Equal("{\"Value\":0}", deserializedList[2].ToString());
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DeserializeTestsEx.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DeserializeTestsEx.cs
@@ -13,6 +13,13 @@ namespace DevExtreme.AspNet.Data.Tests {
             var deserializedList = JsonConvert.DeserializeObject<IList>(rawJsonCriteria);
             Assert.Equal(3, deserializedList.Count);
         }
+
+        [Fact]
+        public void FilterOperandValueCanBeObject() {
+            var deserializedList = JsonConvert.DeserializeObject<IList>(@"[""fieldName1"",""="",{""Value"":0}]");
+            Assert.Equal(3, deserializedList.Count);
+            Assert.Equal("{\r\n  \"Value\": 0\r\n}", deserializedList[2].ToString());
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Compatibility.cs
+++ b/net/DevExtreme.AspNet.Data/Compatibility.cs
@@ -43,6 +43,8 @@ namespace DevExtreme.AspNet.Data {
                     if(jsonElement.TryGetDecimal(out var decimalValue))
                         return decimalValue;
                     throw new NotImplementedException();
+                case JsonValueKind.Object:
+                    return jsonElement;
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
Fixes https://devexpress.com/issue=T1250019

See Also: #620