### PR TITLE
Mitigate violation CA1854

### DIFF
--- a/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
@@ -51,7 +51,8 @@ namespace DevExtreme.AspNet.Data.Aggregation {
             if(_defaultValues == null)
                 _defaultValues = new Dictionary<string, object>();
 
-            if(!_defaultValues.TryGetValue(selector, out object value)) {
+            object value;
+            if(!_defaultValues.TryGetValue(selector, out value)) {
                 var expr = CompileAccessorExpression(CreateItemParam(), selector);
                 var acc = AccumulatorFactory.Create(Utils.StripNullableType(expr.Type));
                 value = acc.GetValue();

--- a/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
@@ -51,13 +51,14 @@ namespace DevExtreme.AspNet.Data.Aggregation {
             if(_defaultValues == null)
                 _defaultValues = new Dictionary<string, object>();
 
-            if(!_defaultValues.ContainsKey(selector)) {
+            if(!_defaultValues.TryGetValue(selector, out object value)) {
                 var expr = CompileAccessorExpression(CreateItemParam(), selector);
                 var acc = AccumulatorFactory.Create(Utils.StripNullableType(expr.Type));
-                _defaultValues[selector] = acc.GetValue();
+                value = acc.GetValue();
+                _defaultValues[selector] = value;
             }
 
-            return _defaultValues[selector];
+            return value;
         }
     }
 

--- a/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
+++ b/net/DevExtreme.AspNet.Data/Aggregation/SumFix.cs
@@ -55,8 +55,7 @@ namespace DevExtreme.AspNet.Data.Aggregation {
             if(!_defaultValues.TryGetValue(selector, out value)) {
                 var expr = CompileAccessorExpression(CreateItemParam(), selector);
                 var acc = AccumulatorFactory.Create(Utils.StripNullableType(expr.Type));
-                value = acc.GetValue();
-                _defaultValues[selector] = value;
+                _defaultValues.Add(selector, value = acc.GetValue());
             }
 
             return value;

--- a/net/DevExtreme.AspNet.Data/GroupHelper.cs
+++ b/net/DevExtreme.AspNet.Data/GroupHelper.cs
@@ -40,7 +40,8 @@ namespace DevExtreme.AspNet.Data {
                 var groupKey = GetKey(item, groupInfo);
                 var groupIndexKey = groupKey ?? NULL_KEY;
 
-                if(!groupsIndex.TryGetValue(groupIndexKey, out Group group)) {
+                Group group;
+                if(!groupsIndex.TryGetValue(groupIndexKey, out group)) {
                     var newGroup = new Group { key = groupKey };
                     group = newGroup;
                     groupsIndex[groupIndexKey] = group;

--- a/net/DevExtreme.AspNet.Data/GroupHelper.cs
+++ b/net/DevExtreme.AspNet.Data/GroupHelper.cs
@@ -40,13 +40,13 @@ namespace DevExtreme.AspNet.Data {
                 var groupKey = GetKey(item, groupInfo);
                 var groupIndexKey = groupKey ?? NULL_KEY;
 
-                if(!groupsIndex.ContainsKey(groupIndexKey)) {
+                if(!groupsIndex.TryGetValue(groupIndexKey, out Group group)) {
                     var newGroup = new Group { key = groupKey };
-                    groupsIndex[groupIndexKey] = newGroup;
+                    group = newGroup;
+                    groupsIndex[groupIndexKey] = group;
                     groups.Add(newGroup);
                 }
 
-                var group = groupsIndex[groupIndexKey];
                 if(group.items == null)
                     group.items = new List<T>();
                 group.items.Add(item);

--- a/net/DevExtreme.AspNet.Data/GroupHelper.cs
+++ b/net/DevExtreme.AspNet.Data/GroupHelper.cs
@@ -43,8 +43,7 @@ namespace DevExtreme.AspNet.Data {
                 Group group;
                 if(!groupsIndex.TryGetValue(groupIndexKey, out group)) {
                     var newGroup = new Group { key = groupKey };
-                    group = newGroup;
-                    groupsIndex[groupIndexKey] = group;
+                    groupsIndex.Add(groupIndexKey, group = newGroup);
                     groups.Add(newGroup);
                 }
 

--- a/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
@@ -16,16 +16,16 @@ namespace DevExtreme.AspNet.Data.Helpers {
             if(_accessors == null)
                 _accessors = new Dictionary<string, Func<T, object>>();
 
-            if(!_accessors.ContainsKey(selector)) {
+            if(!_accessors.TryGetValue(selector, out Func<T, object> func)) {
                 var param = CreateItemParam();
-
-                _accessors[selector] = Expression.Lambda<Func<T, object>>(
+                func = Expression.Lambda<Func<T, object>>(
                     Expression.Convert(CompileAccessorExpression(param, selector), typeof(Object)),
                     param
                 ).Compile();
+                _accessors[selector] = func;
             }
 
-            return _accessors[selector](obj);
+            return func(obj);
         }
     }
 

--- a/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
@@ -19,11 +19,10 @@ namespace DevExtreme.AspNet.Data.Helpers {
             Func<T, object> func;
             if(!_accessors.TryGetValue(selector, out func)) {
                 var param = CreateItemParam();
-                func = Expression.Lambda<Func<T, object>>(
+                _accessors.Add(selector, func = Expression.Lambda<Func<T, object>>(
                     Expression.Convert(CompileAccessorExpression(param, selector), typeof(Object)),
                     param
-                ).Compile();
-                _accessors[selector] = func;
+                ).Compile());
             }
 
             return func(obj);

--- a/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DefaultAccessor.cs
@@ -16,7 +16,8 @@ namespace DevExtreme.AspNet.Data.Helpers {
             if(_accessors == null)
                 _accessors = new Dictionary<string, Func<T, object>>();
 
-            if(!_accessors.TryGetValue(selector, out Func<T, object> func)) {
+            Func<T, object> func;
+            if(!_accessors.TryGetValue(selector, out func)) {
                 var param = CreateItemParam();
                 func = Expression.Lambda<Func<T, object>>(
                     Expression.Convert(CompileAccessorExpression(param, selector), typeof(Object)),


### PR DESCRIPTION
Patch for #634
After bumping target frameworks, the [CA1854](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1854) code analysis violation is triggered.