### PR TITLE
CI: Update external actions, setup missing only dotnet versions

### DIFF
--- a/.github/actions/dotnet-test-build/action.yml
+++ b/.github/actions/dotnet-test-build/action.yml
@@ -5,14 +5,8 @@ runs:
   using: "composite"
 
   steps:
-  - uses: actions/setup-dotnet@v3
-    with:
-      dotnet-quality: ga
-      dotnet-version: |
-        8.0
-        9.0
 
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     with:
       key: ${{ runner.os }}-nuget-${{ hashFiles('net/**/*.csproj') }}
       restore-keys: ${{ runner.os }}-nuget-

--- a/.github/actions/dotnet-test-build/action.yml
+++ b/.github/actions/dotnet-test-build/action.yml
@@ -5,6 +5,10 @@ runs:
   using: "composite"
 
   steps:
+  - uses: actions/setup-dotnet@v3
+    with:
+      dotnet-quality: ga
+      dotnet-version: 9.0
 
   - uses: actions/cache@v4
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - run: git config --global core.autocrlf true
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - run: curl -L https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.3.5/ec-linux-amd64.tar.gz  | tar xzf - -C /opt
     - run: /opt/bin/ec-linux-amd64 -v
@@ -46,7 +46,7 @@ jobs:
           - '>=23.1.0'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - run: node build/make-nojquery
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - run: nuget install -Verbosity quiet -ExcludeVersion -OutputDirectory . -Version 2022.2.3 JetBrains.dotCover.CommandLineTools
 
@@ -77,7 +77,7 @@ jobs:
 
     - run: JetBrains.dotCover.CommandLineTools\tools\dotCover cover --ReturnTargetExitCode --ReportType=DetailedXML --Filters="+:module=DevExtreme.AspNet.Data" --Output=coverage_dotnet.xml --TargetExecutable=net\dotnet-test-all.cmd
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         files: coverage_dotnet.xml
 
@@ -91,11 +91,9 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-quality: ga
-        dotnet-version: |
-          3.1
-          8.0
+        dotnet-version: 3.1
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - if: ${{ env.RELEASE_KEY_SECRET != '' }}
       run: |
@@ -112,7 +110,7 @@ jobs:
     - if: ${{ env.RELEASE_KEY_SECRET != '' }}
       run: dotnet pack net/DevExtreme.AspNet.Data --configuration=Release --include-symbols
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: release-packages
         path: |
@@ -123,12 +121,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - run: dotnet build net/DevExtreme.AspNet.Data
     - run: net\docfx\build.cmd
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: docfx-site
         path: net/docfx/build/site

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,6 +64,11 @@ jobs:
 
     # Custom build for C#
     - if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9
+
+    - if: matrix.language == 'csharp'
       uses: ./.github/actions/dotnet-test-build
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,11 +64,6 @@ jobs:
 
     # Custom build for C#
     - if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9
-
-    - if: matrix.language == 'csharp'
       uses: ./.github/actions/dotnet-test-build
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
- Bump all `actions/*@v3` to `@v4` (except for `codecov/codecov-action@v3`) because of `Error: This request has been automatically failed because it uses a deprecated version of 'actions/*: v3'`
- Install missing in a runner / image only (such as #602) dotnet versions (tested with `dotnet --list-sdks`)

See Also:
https://github.com/DevExpress/devextreme-documentation/pull/6971