### PR TITLE
CI: Setup release-packages on ubuntu-latest

### DIFF
--- a/.github/actions/dotnet-test-build/action.yml
+++ b/.github/actions/dotnet-test-build/action.yml
@@ -5,10 +5,11 @@ runs:
   using: "composite"
 
   steps:
-  - uses: actions/setup-dotnet@v3
-    with:
-      dotnet-quality: ga
-      dotnet-version: 9.0
+  # # enable when a next .net preview sdk (not in an image) is needed
+  # - uses: actions/setup-dotnet@v4
+  #   with:
+  #     dotnet-quality: ga
+  #     dotnet-version: 10.0
 
   - uses: actions/cache@v4
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-quality: ga
-        dotnet-version: 3.1
+        dotnet-version: |
+          3.1
+          8.0
 
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Patch for #654.
Even though the .net 8 sdk is pre-installed on both win and ubuntu images, installing a lower version affects the global cfg (on linux only).