### PR TITLE
Add default Write / Serialization functionality / behavior for System.Text.Json converters

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DeserializeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DeserializeTests.cs
@@ -1,25 +1,23 @@
-﻿using System.Collections;
+﻿using DevExtreme.AspNet.Data.Helpers;
+
+using System.Collections;
 using System.Text.Json;
 using Xunit;
 
 namespace DevExtreme.AspNet.Data.Tests {
 
     public class DeserializeTests {
-        static readonly JsonSerializerOptions TESTS_DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
-            Converters = { new ListConverter() }
-        };
-
         [Theory]
         [InlineData(@"[""fieldName"",""="",null]")]
         [InlineData(@"[[""fieldName1"",""="",""""],""and"",[""fieldName2"",""="",null]]")]
         public void FilterOperandValueCanBeNull(string rawJsonCriteria) {
-            var deserializedList = JsonSerializer.Deserialize<IList>(rawJsonCriteria, TESTS_DEFAULT_SERIALIZER_OPTIONS);
+            var deserializedList = JsonSerializer.Deserialize<IList>(rawJsonCriteria, DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS);
             Assert.Equal(3, deserializedList.Count);
         }
 
         [Fact]
         public void FilterOperandValueCanBeObject() {
-            var deserializedList = JsonSerializer.Deserialize<IList>(@"[""fieldName1"",""="",{""Value"":0}]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
+            var deserializedList = JsonSerializer.Deserialize<IList>(@"[""fieldName1"",""="",{""Value"":0}]", DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS);
             Assert.Equal(3, deserializedList.Count);
             Assert.Equal("{\"Value\":0}", deserializedList[2].ToString());
         }

--- a/net/DevExtreme.AspNet.Data.Tests/SerializeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SerializeTests.cs
@@ -41,13 +41,20 @@ namespace DevExtreme.AspNet.Data.Tests {
                 //, DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS
                 // does not require options, because deserializes from just serialized instance
                 );
-            Assert.Equal("100", loadOptionsDeserialized.Group[0].GroupInterval);
-            Assert.Equal("freight", loadOptionsDeserialized.Group[0].Selector);
-            Assert.Equal(3, loadOptionsDeserialized.Filter.Count);
-            var strFilter0STJ = (IList<object>)loadOptionsDeserialized.Filter[0];
-            Assert.Equal("orderDate", strFilter0STJ[0]);
-            Assert.Equal(">=", strFilter0STJ[1]);
-            Assert.Equal("2011-12-13T14:15:16", strFilter0STJ[2]);
+            Assert.Equal(loadOptions.Group[0].GroupInterval, loadOptionsDeserialized.Group[0].GroupInterval);
+            Assert.Equal(loadOptions.Group[0].Selector, loadOptionsDeserialized.Group[0].Selector);
+            Assert.Equal(loadOptions.Filter.Count, loadOptionsDeserialized.Filter.Count);
+            var filter0Orig = (IList<object>)loadOptions.Filter[0];
+            var filter0STJ = (IList<object>)loadOptionsDeserialized.Filter[0];
+            Assert.Equal(filter0Orig[0], filter0STJ[0]);
+            Assert.Equal(filter0Orig[1], filter0STJ[1]);
+            //TODO:
+            //https://github.com/dotnet/runtime/issues/31423
+            //https://learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support
+            //https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/master/js/dx.aspnet.data.js -> serializeDate
+            //Assert.Equal(filter0Orig[2], filter0STJ[2]);
+            Assert.Equal("2011-12-13T14:15:16", filter0STJ[2]);
+
         }
     }
 

--- a/net/DevExtreme.AspNet.Data.Tests/SerializeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SerializeTests.cs
@@ -1,0 +1,54 @@
+﻿//using DevExtreme.AspNet.Data.Helpers;
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class SerializeTests {
+        [Fact]
+        public void SerializeEmptyOptions() {
+            Assert.Equal(@"{""RequireTotalCount"":false,""RequireGroupCount"":false,""IsCountQuery"":false,""IsSummaryQuery"":false,""Skip"":0,""Take"":0,""Sort"":null,""Group"":null,""Filter"":null,""TotalSummary"":null,""GroupSummary"":null,""Select"":null,""PreSelect"":null,""RemoteSelect"":null,""RemoteGrouping"":null,""ExpandLinqSumType"":null,""PrimaryKey"":null,""DefaultSort"":null,""StringToLower"":null,""PaginateViaPrimaryKey"":null,""SortByPrimaryKey"":null,""AllowAsyncOverSync"":false}",
+                JsonSerializer.Serialize(new DataSourceLoadOptionsBase()));
+        }
+
+        [Fact]
+        public void SerializeDeserializeConvertersAffectedOptions() {
+            var loadOptionsStrGroup = @"""Group"":[{""GroupInterval"":""100"",""IsExpanded"":null,""Selector"":""freight"",""Desc"":false}]";
+            var loadOptionsStrFilter = @"""Filter"":[[""orderDate"",""\u003E="",""2011-12-13T14:15:16""],""and"",[""orderDate"",""\u003C"",""2011-12-13T14:15:17""]]";
+
+            var loadOptions = new DataSourceLoadOptionsBase() {
+                Group = new GroupingInfo[] {
+                    new GroupingInfo() {
+                        GroupInterval = "100",
+                        Selector = "freight"
+                    }
+                },
+                Filter = new List<object>() {
+                    new List<object>() { "orderDate", ">=", new DateTime(2011, 12, 13, 14, 15, 16) },
+                    "and",
+                    new List<object>() { "orderDate", "<", new DateTime(2011, 12, 13, 14, 15, 17) }
+                }
+            };
+
+            var loadOptionsSerialized = JsonSerializer.Serialize(loadOptions);
+            Assert.Contains($"{loadOptionsStrGroup},{loadOptionsStrFilter}", loadOptionsSerialized);
+
+            var loadOptionsDeserialized = JsonSerializer.Deserialize<DataSourceLoadOptionsBase>(
+                loadOptionsSerialized
+                //, DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS
+                // does not require options, because deserializes from just serialized instance
+                );
+            Assert.Equal("100", loadOptionsDeserialized.Group[0].GroupInterval);
+            Assert.Equal("freight", loadOptionsDeserialized.Group[0].Selector);
+            Assert.Equal(3, loadOptionsDeserialized.Filter.Count);
+            var strFilter0STJ = (IList<object>)loadOptionsDeserialized.Filter[0];
+            Assert.Equal("orderDate", strFilter0STJ[0]);
+            Assert.Equal(">=", strFilter0STJ[1]);
+            Assert.Equal("2011-12-13T14:15:16", strFilter0STJ[2]);
+        }
+    }
+
+}

--- a/net/DevExtreme.AspNet.Data.Tests/SerializeTestsEx.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SerializeTestsEx.cs
@@ -37,13 +37,14 @@ namespace DevExtreme.AspNet.Data.Tests {
             Assert.Contains($"{loadOptionsStrGroup},{loadOptionsStrFilter}", loadOptionsSerialized);
 
             var loadOptionsDeserialized = JsonConvert.DeserializeObject<DataSourceLoadOptionsBase>(loadOptionsSerialized);
-            Assert.Equal("100", loadOptionsDeserialized.Group[0].GroupInterval);
-            Assert.Equal("freight", loadOptionsDeserialized.Group[0].Selector);
-            Assert.Equal(3, loadOptionsDeserialized.Filter.Count);
-            var strFilter0NTSF = (JArray)loadOptionsDeserialized.Filter[0];
-            Assert.Equal("orderDate", strFilter0NTSF[0]);
-            Assert.Equal(">=", strFilter0NTSF[1]);
-            Assert.Equal("2011-12-13T14:15:16", strFilter0NTSF[2]);
+            Assert.Equal(loadOptions.Group[0].GroupInterval, loadOptionsDeserialized.Group[0].GroupInterval);
+            Assert.Equal(loadOptions.Group[0].Selector, loadOptionsDeserialized.Group[0].Selector);
+            Assert.Equal(loadOptions.Filter.Count, loadOptionsDeserialized.Filter.Count);
+            var filter0Orig = (IList<object>)loadOptions.Filter[0];
+            var filter0NTSF = (JArray)loadOptionsDeserialized.Filter[0];
+            Assert.Equal(filter0Orig[0], ((JValue)filter0NTSF[0]).Value);
+            Assert.Equal(filter0Orig[1], ((JValue)filter0NTSF[1]).Value);
+            Assert.Equal(filter0Orig[2], ((JValue)filter0NTSF[2]).Value);
         }
     }
 

--- a/net/DevExtreme.AspNet.Data.Tests/SerializeTestsEx.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SerializeTestsEx.cs
@@ -1,0 +1,51 @@
+﻿#if NEWTONSOFT_TESTS
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace DevExtreme.AspNet.Data.Tests {
+
+    public class SerializeTestsEx {
+        [Fact]
+        public void SerializeEmptyOptions() {
+            Assert.Equal(@"{""RequireTotalCount"":false,""RequireGroupCount"":false,""IsCountQuery"":false,""IsSummaryQuery"":false,""Skip"":0,""Take"":0,""Sort"":null,""Group"":null,""Filter"":null,""TotalSummary"":null,""GroupSummary"":null,""Select"":null,""PreSelect"":null,""RemoteSelect"":null,""RemoteGrouping"":null,""ExpandLinqSumType"":null,""PrimaryKey"":null,""DefaultSort"":null,""StringToLower"":null,""PaginateViaPrimaryKey"":null,""SortByPrimaryKey"":null,""AllowAsyncOverSync"":false}",
+                JsonConvert.SerializeObject(new DataSourceLoadOptionsBase()));
+        }
+
+        [Fact]
+        public void SerializeDeserializeConvertersAffectedOptions() {
+            var loadOptionsStrGroup = @"""Group"":[{""GroupInterval"":""100"",""IsExpanded"":null,""Selector"":""freight"",""Desc"":false}]";
+            var loadOptionsStrFilter = @"""Filter"":[[""orderDate"","">="",""2011-12-13T14:15:16""],""and"",[""orderDate"",""<"",""2011-12-13T14:15:17""]]";
+
+            var loadOptions = new DataSourceLoadOptionsBase() {
+                Group = new GroupingInfo[] {
+                    new GroupingInfo() {
+                        GroupInterval = "100",
+                        Selector = "freight"
+                    }
+                },
+                Filter = new List<object>() {
+                    new List<object>() { "orderDate", ">=", new DateTime(2011, 12, 13, 14, 15, 16) },
+                    "and",
+                    new List<object>() { "orderDate", "<", new DateTime(2011, 12, 13, 14, 15, 17) }
+                }
+            };
+
+            var loadOptionsSerialized = JsonConvert.SerializeObject(loadOptions);
+            Assert.Contains($"{loadOptionsStrGroup},{loadOptionsStrFilter}", loadOptionsSerialized);
+
+            var loadOptionsDeserialized = JsonConvert.DeserializeObject<DataSourceLoadOptionsBase>(loadOptionsSerialized);
+            Assert.Equal("100", loadOptionsDeserialized.Group[0].GroupInterval);
+            Assert.Equal("freight", loadOptionsDeserialized.Group[0].Selector);
+            Assert.Equal(3, loadOptionsDeserialized.Filter.Count);
+            var strFilter0NTSF = (JArray)loadOptionsDeserialized.Filter[0];
+            Assert.Equal("orderDate", strFilter0NTSF[0]);
+            Assert.Equal(">=", strFilter0NTSF[1]);
+            Assert.Equal("2011-12-13T14:15:16", strFilter0NTSF[2]);
+        }
+    }
+
+}
+#endif

--- a/net/DevExtreme.AspNet.Data/Compatibility.cs
+++ b/net/DevExtreme.AspNet.Data/Compatibility.cs
@@ -66,7 +66,7 @@ namespace DevExtreme.AspNet.Data {
             throw new NotImplementedException();
         }
 
-        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) => throw new NotImplementedException();
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) => writer.WriteStringValue(value);
     }
 
     class ListConverter : JsonConverter<IList> {
@@ -75,7 +75,10 @@ namespace DevExtreme.AspNet.Data {
             return Compatibility.UnwrapList(deserializedList);
         }
 
-        public override void Write(Utf8JsonWriter writer, IList value, JsonSerializerOptions options) => throw new NotImplementedException();
+        public override void Write(Utf8JsonWriter writer, IList value, JsonSerializerOptions options) {
+            var serializedList = JsonSerializer.Serialize(value);
+            writer.WriteStringValue(serializedList);
+        }
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Compatibility.cs
+++ b/net/DevExtreme.AspNet.Data/Compatibility.cs
@@ -75,10 +75,7 @@ namespace DevExtreme.AspNet.Data {
             return Compatibility.UnwrapList(deserializedList);
         }
 
-        public override void Write(Utf8JsonWriter writer, IList value, JsonSerializerOptions options) {
-            var serializedList = JsonSerializer.Serialize(value);
-            writer.WriteStringValue(serializedList);
-        }
+        public override void Write(Utf8JsonWriter writer, IList value, JsonSerializerOptions options) => JsonSerializer.Serialize(writer, value, value.GetType(), options);
     }
 
 }

--- a/net/DevExtreme.AspNet.Data/Helpers/DataSourceLoadOptionsParser.cs
+++ b/net/DevExtreme.AspNet.Data/Helpers/DataSourceLoadOptionsParser.cs
@@ -8,6 +8,9 @@ namespace DevExtreme.AspNet.Data.Helpers {
     /// A parser for the data processing settings.
     /// </summary>
     public static class DataSourceLoadOptionsParser {
+#if DEBUG
+        internal
+#endif
         static readonly JsonSerializerOptions DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
             Converters = { new ListConverter() }
         };


### PR DESCRIPTION
Patch for #617 and #605

Provides a default Write / Serialization [functionality / behavior](https://github.com/DevExpress/DevExtreme.AspNet.Data/pull/663/files#diff-c5ba8ba2d9de53e0c9962224d942aae728eca34c7caf69c1ce98dfc78a9d4912L69-R78) for ntsf -> stj converters.

Before it fails on attempting to serialize the DataSourceLoadOptionsBase instance, where these converters are in use:
[DataSourceLoadOptionsBase -> Group -> GroupInterval](https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/master/net/DevExtreme.AspNet.Data/GroupingInfo.cs#L12)
[DataSourceLoadOptionsBase -> Filter](https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/master/net/DevExtreme.AspNet.Data/DataSourceLoadOptionsBase.cs#L59)

[Serialization results / tests](https://github.com/DevExpress/DevExtreme.AspNet.Data/pull/663/files#diff-ce371af9ec827d83ad6e56282c0a67a874645c539913c3b8e4d0371d562bdbdeR19-R37)