### PR TITLE
Refactor tests with JsonSerializerOptions

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/CustomFilterCompilersTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/CustomFilterCompilersTests.cs
@@ -11,9 +11,6 @@ using Xunit;
 namespace DevExtreme.AspNet.Data.Tests {
 
     public class CustomFilterCompilersTests {
-        static readonly JsonSerializerOptions TESTS_DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
-            Converters = { new ListConverter() }
-        };
 
         [Fact]
         public void OneToManyContains() {
@@ -38,7 +35,7 @@ namespace DevExtreme.AspNet.Data.Tests {
                 var source = new[] { new Category(), new Category() };
                 source[0].Products.Add(new Product { Name = "Chai" });
 
-                var filter = JsonSerializer.Deserialize<IList>(@"[ ""Products"", ""Contains"", ""ch"" ]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
+                var filter = JsonSerializer.Deserialize<IList>(@"[ ""Products"", ""Contains"", ""ch"" ]", DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS);
 
                 var loadOptions = new SampleLoadOptions {
                     Filter = filter,

--- a/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/FilterExpressionCompilerTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using DevExtreme.AspNet.Data.Helpers;
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +11,6 @@ using Xunit;
 namespace DevExtreme.AspNet.Data.Tests {
 
     public class FilterExpressionCompilerTests {
-        static readonly JsonSerializerOptions TESTS_DEFAULT_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web) {
-            Converters = { new ListConverter() }
-        };
 
         class DataItem1 {
             public int IntProp { get; set; }
@@ -146,7 +145,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void IsUnaryWithJsonCriteria() {
-            var crit = JsonSerializer.Deserialize<IList>("[\"!\", []]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
+            var crit = JsonSerializer.Deserialize<IList>("[\"!\", []]", DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS);
             var compiler = new FilterExpressionCompiler(typeof(object), false);
             Assert.True(compiler.IsUnary(crit));
         }
@@ -243,7 +242,7 @@ namespace DevExtreme.AspNet.Data.Tests {
 
         [Fact]
         public void JsonObjects() {
-            var crit = JsonSerializer.Deserialize<IList>(@"[ [ ""StringProp"", ""abc"" ], [ ""NullableProp"", null ] ]", TESTS_DEFAULT_SERIALIZER_OPTIONS);
+            var crit = JsonSerializer.Deserialize<IList>(@"[ [ ""StringProp"", ""abc"" ], [ ""NullableProp"", null ] ]", DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS);
             var expr = Compile<DataItem1>(crit);
             Assert.Equal(@"((obj.StringProp == ""abc"") AndAlso (obj.NullableProp == null))", expr.Body.ToString());
         }

--- a/net/DevExtreme.AspNet.Data.Tests/SerializeTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/SerializeTests.cs
@@ -54,7 +54,6 @@ namespace DevExtreme.AspNet.Data.Tests {
             //https://github.com/DevExpress/DevExtreme.AspNet.Data/blob/master/js/dx.aspnet.data.js -> serializeDate
             //Assert.Equal(filter0Orig[2], filter0STJ[2]);
             Assert.Equal("2011-12-13T14:15:16", filter0STJ[2]);
-
         }
     }
 


### PR DESCRIPTION
Complete get rid of `TESTS_DEFAULT_SERIALIZER_OPTIONS`, a copy of `DataSourceLoadOptionsParser.DEFAULT_SERIALIZER_OPTIONS` for tests
- Introduced at #620 and #617
- Partially removed in prev #663 + re-shared internal options for tests (`internal` under `DEBUG` + `assembly: InternalsVisibleTo`)