### PR TITLE
DataSourceLoader - Update DynamicClassBridge class to use renamed DynamicClass indexer in System.Linq.Dynamic.Core v1.6.8

### DIFF
--- a/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
@@ -1,6 +1,10 @@
 ﻿using DevExtreme.AspNet.Data.ResponseModel;
+using DevExtreme.AspNet.Data.Types;
+
 using System;
 using System.Linq;
+using System.Reflection;
+
 using Xunit;
 
 namespace DevExtreme.AspNet.Data.Tests {
@@ -107,6 +111,27 @@ namespace DevExtreme.AspNet.Data.Tests {
             var item = loadResult.data.Cast<System.Collections.Generic.IDictionary<string, object>>().First();
 
             Assert.Equal(42, item["p"]);
+        }
+
+        [Fact]
+        public void DynamicClassBridge_Indexer_GetMember_RoundTripsValue() {
+            var expectedValue = "test";
+            var dynamicType = CallDynamicClassBridgeCreateType(new[] { typeof(string) });
+            var instance = Activator.CreateInstance(dynamicType, expectedValue);
+            Assert.Equal(expectedValue, CallDynamicClassBridgeGetIndexerMember(instance, 0));
+        }
+
+        static MethodInfo GetDynamicClassBridgeMethod(string methodName) {
+            var bridgeType = typeof(AnonType).Assembly.GetType("DevExtreme.AspNet.Data.Types.DynamicClassBridge");
+            return bridgeType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        }
+
+        static Type CallDynamicClassBridgeCreateType(Type[] memberTypes) {
+            return (Type)GetDynamicClassBridgeMethod("CreateType").Invoke(null, new object[] { memberTypes });
+        }
+
+        static object CallDynamicClassBridgeGetIndexerMember(object obj, int index) {
+            return GetDynamicClassBridgeMethod("GetMember").Invoke(null, new object[] { obj, index });
         }
 
     }

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
@@ -1,10 +1,6 @@
 ﻿using DevExtreme.AspNet.Data.ResponseModel;
-using DevExtreme.AspNet.Data.Types;
-
 using System;
 using System.Linq;
-using System.Reflection;
-
 using Xunit;
 
 namespace DevExtreme.AspNet.Data.Tests {
@@ -111,27 +107,6 @@ namespace DevExtreme.AspNet.Data.Tests {
             var item = loadResult.data.Cast<System.Collections.Generic.IDictionary<string, object>>().First();
 
             Assert.Equal(42, item["p"]);
-        }
-
-        [Fact]
-        public void DynamicClassBridge_Indexer_GetMember_RoundTripsValue() {
-            var expectedValue = "test";
-            var dynamicType = CallDynamicClassBridgeCreateType(new[] { typeof(string) });
-            var instance = Activator.CreateInstance(dynamicType, expectedValue);
-            Assert.Equal(expectedValue, CallDynamicClassBridgeGetIndexerMember(instance, 0));
-        }
-
-        static MethodInfo GetDynamicClassBridgeMethod(string methodName) {
-            var bridgeType = typeof(AnonType).Assembly.GetType("DevExtreme.AspNet.Data.Types.DynamicClassBridge");
-            return bridgeType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
-        }
-
-        static Type CallDynamicClassBridgeCreateType(Type[] memberTypes) {
-            return (Type)GetDynamicClassBridgeMethod("CreateType").Invoke(null, new object[] { memberTypes });
-        }
-
-        static object CallDynamicClassBridgeGetIndexerMember(object obj, int index) {
-            return GetDynamicClassBridgeMethod("GetMember").Invoke(null, new object[] { obj, index });
         }
 
     }

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
@@ -93,22 +93,6 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
         }
 
-        [Fact]
-        public void Select_WithMoreThan32Fields_ReturnsValues() {
-            var source = new[] { new { p = 42 } };
-
-            var loadOptions = new SampleLoadOptions {
-                GuardNulls = false,
-                RemoteSelect = true,
-                Select = Enumerable.Repeat("p", 33).ToArray()
-            };
-
-            var loadResult = DataSourceLoader.Load(source, loadOptions);
-            var item = loadResult.data.Cast<System.Collections.Generic.IDictionary<string, object>>().First();
-
-            Assert.Equal(42, item["p"]);
-        }
-
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
@@ -93,6 +93,22 @@ namespace DevExtreme.AspNet.Data.Tests {
             );
         }
 
+        [Fact]
+        public void Select_WithMoreThan32Fields_ReturnsValues() {
+            var source = new[] { new { p = 42 } };
+
+            var loadOptions = new SampleLoadOptions {
+                GuardNulls = false,
+                RemoteSelect = true,
+                Select = Enumerable.Repeat("p", 33).ToArray()
+            };
+
+            var loadResult = DataSourceLoader.Load(source, loadOptions);
+            var item = loadResult.data.Cast<System.Collections.Generic.IDictionary<string, object>>().First();
+
+            Assert.Equal(42, item["p"]);
+        }
+
     }
 
 }

--- a/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
+++ b/net/DevExtreme.AspNet.Data.Tests/DynamicClassTests.cs
@@ -2,6 +2,7 @@
 using DevExtreme.AspNet.Data.Types;
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -108,7 +109,7 @@ namespace DevExtreme.AspNet.Data.Tests {
             };
 
             var loadResult = DataSourceLoader.Load(source, loadOptions);
-            var item = loadResult.data.Cast<System.Collections.Generic.IDictionary<string, object>>().First();
+            var item = loadResult.data.Cast<IDictionary<string, object>>().First();
 
             Assert.Equal(42, item["p"]);
         }

--- a/net/DevExtreme.AspNet.Data/Types/DynamicClassBridge.cs
+++ b/net/DevExtreme.AspNet.Data/Types/DynamicClassBridge.cs
@@ -23,7 +23,10 @@ namespace DevExtreme.AspNet.Data.Types {
                 PROP_TYPE = assembly.GetType("System.Linq.Dynamic.Core.DynamicProperty");
 #pragma warning restore DX0010,DX0004 // known assembly and types
                 CREATE_TYPE_METHOD = FACTORY_TYPE.GetMethod("CreateType");
-                INDEXER_METHOD = CLASS_TYPE.GetMethod("get_Item");
+
+                var indexerNameField = CLASS_TYPE.GetField("IndexerName", BindingFlags.NonPublic | BindingFlags.Static);
+                var indexerName = indexerNameField?.GetValue(null) as string ?? "Item";
+                INDEXER_METHOD = CLASS_TYPE.GetMethod("get_" + indexerName);
             } catch(FileNotFoundException x) {
                 throw new Exception("Please install 'System.Linq.Dynamic.Core' package", x);
             }

--- a/net/DevExtreme.AspNet.Data/Types/DynamicClassBridge.cs
+++ b/net/DevExtreme.AspNet.Data/Types/DynamicClassBridge.cs
@@ -23,10 +23,7 @@ namespace DevExtreme.AspNet.Data.Types {
                 PROP_TYPE = assembly.GetType("System.Linq.Dynamic.Core.DynamicProperty");
 #pragma warning restore DX0010,DX0004 // known assembly and types
                 CREATE_TYPE_METHOD = FACTORY_TYPE.GetMethod("CreateType");
-
-                var indexerNameField = CLASS_TYPE.GetField("IndexerName", BindingFlags.NonPublic | BindingFlags.Static);
-                var indexerName = indexerNameField?.GetValue(null) as string ?? "Item";
-                INDEXER_METHOD = CLASS_TYPE.GetMethod("get_" + indexerName);
+                INDEXER_METHOD = CLASS_TYPE.GetMethod("get_Item");
             } catch(FileNotFoundException x) {
                 throw new Exception("Please install 'System.Linq.Dynamic.Core' package", x);
             }

--- a/net/Directory.Packages.props
+++ b/net/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.8" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
Caused by / v1.6.8:
- https://github.com/zzzprojects/System.Linq.Dynamic.Core/pull/948